### PR TITLE
fix: No longer create a new security manager in RoleManager.manage_getUserRolesAndPermissions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ For changes before verison 3.0, see ``HISTORY.txt``.
 3.0.9 (unreleased)
 ------------------
 
+- LP #1248529: No longer create a new security manager in
+  RoleManager.manage_getUserRolesAndPermissions
 
 3.0.8 (2013-07-16)
 ------------------

--- a/src/AccessControl/rolemanager.py
+++ b/src/AccessControl/rolemanager.py
@@ -158,7 +158,6 @@ class RoleManager(Base, RoleManager):
             else:
                 current = current.__parent__
 
-        newSecurityManager(None, userObj) # necessary?
         userObj = userObj.__of__(uf)
 
         d = {'user_defined_in': '/' + uf.absolute_url(1)}

--- a/src/AccessControl/tests/testRole.py
+++ b/src/AccessControl/tests/testRole.py
@@ -1,7 +1,42 @@
 import unittest
 
+from AccessControl.rolemanager import RoleManager
+from Acquisition import Implicit, Explicit
+
+
+class DummyContext(Implicit, RoleManager):
+    __roles__ = ('Manager',)
+
+
+class DummyUser(Explicit):
+    def getRoles(self):
+        return ('Manager',)
+
+    def getRolesInContext(self, context):
+        return ('Manager',)
+
+    def has_permission(self, permission, context):
+        return True
+
+
+class DummyAclUsers(Explicit):
+    def getUser(self, user_id):
+        user = DummyUser()
+        return user.__of__(self)
+
+    def absolute_url(self, relative=0):
+        return 'acl_users'
+
+
+class DummyRoot(Explicit):
+    acl_users = DummyAclUsers()
+
 
 class TestRoleManager(unittest.TestCase):
+
+    def tearDown(self):
+        from AccessControl.SecurityManagement import noSecurityManager
+        noSecurityManager()
 
     def test_interfaces(self):
         from AccessControl.interfaces import IRoleManager
@@ -9,3 +44,18 @@ class TestRoleManager(unittest.TestCase):
         from zope.interface.verify import verifyClass
 
         verifyClass(IRoleManager, RoleManager)
+
+    def test_manage_getUserRolesAndPermissions(self):
+        from AccessControl.ImplPython import verifyAcquisitionContext
+        from AccessControl.SecurityManagement import getSecurityManager
+        from AccessControl.SecurityManagement import newSecurityManager
+
+        root = DummyRoot()
+        root.acl_users = DummyAclUsers()
+        user = DummyUser().__of__(root.acl_users)
+        newSecurityManager(None, user)
+        root.context1 = DummyContext()
+        root.context2 = DummyContext()
+        root.context1.manage_getUserRolesAndPermissions('dummy_user')
+        user = getSecurityManager().getUser()
+        self.assertIsNotNone(verifyAcquisitionContext(user, root.context2, ()))


### PR DESCRIPTION
As seen in issue #4
