### PR TITLE
Modernised C code: use PyVarObject_HEAD_INIT.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ For changes before verison 3.0, see ``HISTORY.txt``.
 3.0.13 (unreleased)
 -------------------
 
-- TBD
+- Modernised C code in preparation of porting to Python 3.
 
 3.0.12 (2015-12-21)
 -------------------

--- a/include/ExtensionClass/ExtensionClass.h
+++ b/include/ExtensionClass/ExtensionClass.h
@@ -214,7 +214,7 @@ static PyExtensionClass NAME ## Type = { PyObject_HEAD_INIT(NULL) 0, # NAME, \
 /* Check whether an object has an __of__ method for returning itself
    in the context of its container. */
 #define has__of__(O) (PyObject_TypeCheck((O)->ob_type, ECExtensionClassType) \
-                      && (O)->ob_type->tp_descr_get != NULL)
+                      && Py_TYPE(O)->tp_descr_get != NULL)
 
 /* The following macros are used to check whether an instance
    or a class' instanses have instance dictionaries: */
@@ -256,9 +256,9 @@ static PyExtensionClass NAME ## Type = { PyObject_HEAD_INIT(NULL) 0, # NAME, \
 #undef PyObject_DEL
 
 #define PyMem_DEL(O)                                   \
-  if (((O)->ob_type->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
-      && ((O)->ob_type->tp_free != NULL))              \
-    (O)->ob_type->tp_free((PyObject*)(O));             \
+  if ((Py_TYPE(O)->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
+      && (Py_TYPE(O)->tp_free != NULL))              \
+    Py_TYPE(O)->tp_free((PyObject*)(O));             \
   else                                                 \
     PyObject_FREE((O));
 

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -429,7 +429,7 @@ static PyMethodDef ZopeSecurityPolicy_methods[] = {
 };
 
 static PyExtensionClass ZopeSecurityPolicyType = {
-	PyObject_HEAD_INIT(NULL) 0,
+       PyVarObject_HEAD_INIT(NULL, 0)
 	"ZopeSecurityPolicy",			/* tp_name	*/
 	sizeof(ZopeSecurityPolicy),		/* tp_basicsize	*/
 	0,					/* tp_itemsize	*/
@@ -488,7 +488,7 @@ static PyMethodDef SecurityManager_methods[] = {
 };
 
 static PyExtensionClass SecurityManagerType = {
-	PyObject_HEAD_INIT(NULL) 0,
+       PyVarObject_HEAD_INIT(NULL, 0)
 	"SecurityManager",			/* tp_name	*/
 	sizeof(SecurityManager),		/* tp_basicsize	*/
 	0,					/* tp_itemsize	*/
@@ -547,7 +547,7 @@ static PyMethodDef PermissionRole_methods[] = {
 };
 
 static PyExtensionClass PermissionRoleType = {
-	PyObject_HEAD_INIT(NULL) 0,
+       PyVarObject_HEAD_INIT(NULL, 0)
 	"PermissionRole",			/* tp_name	*/
 	sizeof(PermissionRole),			/* tp_basicsize	*/
 	0,					/* tp_itemsize	*/
@@ -617,7 +617,7 @@ static PySequenceMethods imSequenceMethods = {
 };
 
 static PyExtensionClass imPermissionRoleType = {
-	PyObject_HEAD_INIT(NULL) 0,
+       PyVarObject_HEAD_INIT(NULL, 0)
 	"imPermissionRole",			/* tp_name	*/
 	sizeof(imPermissionRole),		/* tp_basicsize	*/
 	0,					/* tp_itemsize	*/

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -959,7 +959,7 @@ static PyObject *ZopeSecurityPolicy_validate(PyObject *self, PyObject *args) {
 		**|        "__allow_access_to_unprotected_subobjects__", None)
 		*/
 
-		p = callfunction2(Containers, OBJECT(container->ob_type),
+		p = callfunction2(Containers, OBJECT(Py_TYPE(container)),
                                   Py_None);
 		if (p == NULL)
                   goto err;
@@ -1309,7 +1309,7 @@ static PyObject *ZopeSecurityPolicy_validate(PyObject *self, PyObject *args) {
 
 static void ZopeSecurityPolicy_dealloc(ZopeSecurityPolicy *self) {
 
-	Py_DECREF(self->ob_type);	/* Extensionclass init incref'd */
+       Py_DECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
 	PyObject_DEL(self);  
 }
 
@@ -1393,7 +1393,7 @@ SecurityManager_dealloc(SecurityManager *self)
   Py_XDECREF(self->policy);
   Py_XDECREF(self->validate);
   Py_XDECREF(self->checkPermission);
-  Py_DECREF(self->ob_type);	/* Extensionclass init incref'd */
+  Py_DECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
   PyObject_DEL(self);  
 }
 
@@ -1589,7 +1589,7 @@ static void PermissionRole_dealloc(PermissionRole *self) {
 
 	Py_XDECREF(self->__roles__);
 
-	Py_XDECREF(self->ob_type);	/* Extensionclass init incref'd */
+	Py_XDECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
 
 	PyObject_DEL(self);  
 }
@@ -1735,7 +1735,7 @@ static void imPermissionRole_dealloc(imPermissionRole *self) {
 
 	Py_XDECREF(self->_v);
 
-	Py_DECREF(self->ob_type);	/* Extensionclass init incref'd */
+	Py_DECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
 
 	PyObject_DEL(self);  
 }
@@ -2047,7 +2047,7 @@ guarded_getattr(PyObject *inst, PyObject *name, PyObject *default_,
 
         assertion = Containers(type(inst))
       */
-      t = PyDict_GetItem(ContainerAssertions, OBJECT(inst->ob_type));
+      t = PyDict_GetItem(ContainerAssertions, OBJECT(Py_TYPE(inst)));
       if (t != NULL)
         {
 
@@ -2076,7 +2076,7 @@ guarded_getattr(PyObject *inst, PyObject *name, PyObject *default_,
                   if (i < 0) goto err;
                   if (i) 
                     {
-                      if (attrv->ob_type->tp_call)
+                      if (Py_TYPE(attrv)->tp_call)
                         {
                           Py_DECREF(v);
                           v = callfunction2(attrv, inst, name);


### PR DESCRIPTION
These are changes compatible with all supported Python 2 versions, but made in preparation of porting to Python 3. Making these changes outside a Python 3 porting branch allows us to keep the interesting part of the porting smaller and also testing as many changes as possible based on the green bar we have on Python 2.