### PR TITLE
fix Zope2 depending on AccessControl >= 4.0a2 and setuptools interpre…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from os.path import join
 from setuptools import setup, find_packages, Extension
 
 setup(name='AccessControl',
-      version='4.0.dev0',
+      version='4.0-dev0',
       url='http://pypi.python.org/pypi/AccessControl',
       license='ZPL 2.1',
       description="Security framework for Zope2.",


### PR DESCRIPTION
…ting 4.0.dev0 as lower

@hannosch your last release lead into a dependency error by buildout/setuptools:

```
Error: There is a version conflict.
We already have: AccessControl 4.0.dev0
but Zope2 4.0a2.dev0 requires 'AccessControl>=4.0a1'.
```
Also see:
http://jenkins.plone.org/view/PLIPs/job/plip-zope4/33/console

It's a pity that ``.dev0`` cant just used without these kind of problems...
This case should be added to the plone style guide... /cc @svx
https://github.com/plone/documentation/blob/5.0/develop/styleguide/python.rst#versioning-scheme
