### PR TITLE
Added `override_container` context manager.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,9 @@ Changelog
 2.13.15 (unreleased)
 --------------------
 
-- TBD
+- Added ``override_container`` context manager.  Used this in tests to
+  make them pass when the standard permissive security assertions for
+  strings has been changed.  [maurits]
 
 2.13.14 (2015-12-21)
 --------------------

--- a/src/AccessControl/SimpleObjectPolicies.py
+++ b/src/AccessControl/SimpleObjectPolicies.py
@@ -128,8 +128,10 @@ def override_containers(type_, assertions):
     """Temporarily override the container assertions."""
     orig_container = Containers(type_, _marker)
     ContainerAssertions[type_] = assertions
-    yield
-    if orig_container is _marker:
-        del ContainerAssertions[type_]
-    else:
-        ContainerAssertions[type_] = orig_container
+    try:
+        yield
+    finally:
+        if orig_container is _marker:
+            del ContainerAssertions[type_]
+        else:
+            ContainerAssertions[type_] = orig_container

--- a/src/AccessControl/SimpleObjectPolicies.py
+++ b/src/AccessControl/SimpleObjectPolicies.py
@@ -45,6 +45,7 @@ or in ZopeSecurityPolicy. :(
 
 _noroles = [] # this is imported in various places
 
+from contextlib import contextmanager
 import Record
 
 # Allow access to unprotected attributes
@@ -119,3 +120,13 @@ for tree_type, has_values in [(OOBTree, 1),
     if has_values:
         assert key_type is type(tree.values())
         assert key_type is type(tree.items())
+
+
+@contextmanager
+def override_containers(type_, assertions):
+    """Temporarily override the container assertions."""
+    orig_container = Containers(type_)
+    ContainerAssertions[type_] = assertions
+    yield
+    if orig_container is not None:
+        ContainerAssertions[type_] = orig_container

--- a/src/AccessControl/SimpleObjectPolicies.py
+++ b/src/AccessControl/SimpleObjectPolicies.py
@@ -44,6 +44,7 @@ or in ZopeSecurityPolicy. :(
 '''
 
 _noroles = [] # this is imported in various places
+_marker = object()
 
 from contextlib import contextmanager
 import Record
@@ -125,8 +126,10 @@ for tree_type, has_values in [(OOBTree, 1),
 @contextmanager
 def override_containers(type_, assertions):
     """Temporarily override the container assertions."""
-    orig_container = Containers(type_)
+    orig_container = Containers(type_, _marker)
     ContainerAssertions[type_] = assertions
     yield
-    if orig_container is not None:
+    if orig_container is _marker:
+        del ContainerAssertions[type_]
+    else:
         ContainerAssertions[type_] = orig_container

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -335,6 +335,27 @@ class ZopeSecurityPolicyTestBase(unittest.TestCase):
         v = self.policy.checkPermission(u'View', r_item, o_context)
         self.assert_(v, '_View_Permission should grant access to theowner')
 
+    def testContainersContextManager(self):
+        from AccessControl.SimpleObjectPolicies import override_containers
+        from AccessControl.SimpleObjectPolicies import ContainerAssertions
+        from AccessControl.SimpleObjectPolicies import Containers
+        from types import EllipsisType
+        # Surely we have no assertions for this type.  There might be a good
+        # reason to have then, but I have not even heard of this type.
+        self.assertFalse(EllipsisType in ContainerAssertions)
+        with override_containers(EllipsisType, 1):
+            self.assertTrue(EllipsisType in ContainerAssertions)
+            self.assertEqual(Containers(EllipsisType), 1)
+            # Override it again.
+            with override_containers(EllipsisType, {}):
+                self.assertEqual(Containers(EllipsisType), {})
+            # We are outside the nested override, so the first override should
+            # have been restored.
+            self.assertEqual(Containers(EllipsisType), 1)
+        # We are outside all overrides, so the type should no longer be in the
+        # assertions.
+        self.assertFalse(EllipsisType in ContainerAssertions)
+
     def testAqNames(self):
         policy = self.policy
         names = {


### PR DESCRIPTION
Used this in tests to make them pass when the standard permissive security assertions for strings has been changed.

Related to PloneHotfix20170117.

This pull request is needed to make https://github.com/zopefoundation/Zope/pull/88 pass.