### PR TITLE
Zope2 and Products.ZCatalog both need name_trans for now.

### DIFF
--- a/src/AccessControl/Permission.py
+++ b/src/AccessControl/Permission.py
@@ -14,9 +14,17 @@
 """
 
 from Acquisition import aq_base
+import string
 import re
 
 _NOT_ALLOWED_CHARS = re.compile(r'[^a-zA-Z0-9_]')
+
+
+name_trans = filter(
+    lambda c,
+    an=string.letters + string.digits + '_': c not in an,
+    map(chr, range(256)))
+name_trans = string.maketrans(''.join(name_trans), '_' * len(name_trans))
 
 
 def getPermissionIdentifier(name):


### PR DESCRIPTION
We could copy the name_trans function to those packages instead, but it seems fine to me to keep it here.

This is one commit from the `plonezope4` branch, which has too many changes, including for Python 3 compatibility. That may be fine for the moment, but makes it impractical to review. So this pull request is step one in splitting that up.