### PR TITLE
Harmonize errors raised by 'guarded_hasattr'.

### DIFF
--- a/src/AccessControl/ZopeGuards.py
+++ b/src/AccessControl/ZopeGuards.py
@@ -59,7 +59,7 @@ def initialize(impl):
 def guarded_hasattr(object, name):
     try:
         guarded_getattr(object, name)
-    except (AttributeError, Unauthorized):
+    except (AttributeError, Unauthorized, TypeError):
         return 0
     return 1
 safe_builtins['hasattr'] = guarded_hasattr

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -2143,6 +2143,10 @@ guarded_getattr(PyObject *inst, PyObject *name, PyObject *default_,
       Py_DECREF(v);
       return NULL;
     }
+  } else {
+    /* raise TypeError, name */
+    PyErr_SetObject(PyExc_TypeError, name);
+    return NULL;
   }
 
  unauth:


### PR DESCRIPTION
C and Python should raise the same exceptions in the same cases.

Closes #13.