### PR TITLE
Do not import UnrestrictedUser as Super to prevent ImportErrors

### DIFF
--- a/src/AccessControl/User.py
+++ b/src/AccessControl/User.py
@@ -15,7 +15,7 @@
 
 # BBB
 from AccessControl.users import emergency_user
-from AccessControl.users import UnrestrictedUser as Super
+from AccessControl.users import UnrestrictedUser
 from AccessControl.users import _remote_user_mode
 from AccessControl.users import absattr
 from AccessControl.users import addr_match

--- a/src/AccessControl/User.py
+++ b/src/AccessControl/User.py
@@ -16,6 +16,7 @@
 # BBB
 from AccessControl.users import emergency_user
 from AccessControl.users import UnrestrictedUser
+from AccessControl.users import UnrestrictedUser as Super
 from AccessControl.users import _remote_user_mode
 from AccessControl.users import absattr
 from AccessControl.users import addr_match


### PR DESCRIPTION
The change reverted here caused 23 additional failures in http://jenkins.plone.org/view/PLIPs/job/plip-zope4/27/