### PR TITLE
Drop `Record` dependency, closes #34.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ For changes before version 3.0, see ``HISTORY.rst``.
 4.0a6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop `Record` dependency, which now does its own security declaration.
 
 
 4.0a5 (2017-05-05)

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(name='AccessControl',
           'DateTime',  # optional dependency of RestrictedPython
           'ExtensionClass>=4.2.1',
           'Persistence>=3.0a3',
-          'Record',
           'RestrictedPython >= 4.0a1',
           'six',
           'transaction',

--- a/src/AccessControl/SimpleObjectPolicies.py
+++ b/src/AccessControl/SimpleObjectPolicies.py
@@ -60,13 +60,7 @@ from BTrees.OOBTree import OOBTree
 from BTrees.OOBTree import OOBucket
 from BTrees.OOBTree import OOSet
 
-import Record
-
-
 _noroles = []  # this is imported in various places
-
-# Allow access to unprotected attributes
-Record.Record.__allow_access_to_unprotected_subobjects__ = 1
 
 # ContainerAssertions are used by cAccessControl to check access to
 # attributes of container types, like dict, list, or string.


### PR DESCRIPTION
This requires Record 3.3, which is already part of the Zope master KGS.