### PR TITLE
Py3 C extension

### DIFF
--- a/include/Acquisition/Acquisition.h
+++ b/include/Acquisition/Acquisition.h
@@ -16,17 +16,17 @@
 #define __ACQUISITION_H_
 
 typedef struct {
-    PyObject *(*AQ_Acquire) (PyObject *obj, PyObject *name, PyObject *filter,
-        PyObject *extra, int explicit, PyObject *deflt,
-        int containment);
-    PyObject *(*AQ_Get) (PyObject *obj, PyObject *name, PyObject *deflt,
-        int containment);
-    int (*AQ_IsWrapper) (PyObject *obj);
-    PyObject *(*AQ_Base) (PyObject *obj);
-    PyObject *(*AQ_Parent) (PyObject *obj);
-    PyObject *(*AQ_Self) (PyObject *obj);
-    PyObject *(*AQ_Inner) (PyObject *obj);
-    PyObject *(*AQ_Chain) (PyObject *obj, int containment);
+	PyObject *(*AQ_Acquire) (PyObject *obj, PyObject *name, PyObject *filter,
+		PyObject *extra, int explicit, PyObject *deflt,
+		int containment);
+	PyObject *(*AQ_Get) (PyObject *obj, PyObject *name, PyObject *deflt,
+		int containment);
+	int (*AQ_IsWrapper) (PyObject *obj);
+	PyObject *(*AQ_Base) (PyObject *obj);
+	PyObject *(*AQ_Parent) (PyObject *obj);
+	PyObject *(*AQ_Self) (PyObject *obj);
+	PyObject *(*AQ_Inner) (PyObject *obj);
+	PyObject *(*AQ_Chain) (PyObject *obj, int containment);
 } ACQUISITIONCAPI;
 
 #ifndef _IN_ACQUISITION_C
@@ -44,13 +44,7 @@ typedef struct {
 static ACQUISITIONCAPI *AcquisitionCAPI = NULL;
 
 #define aq_init() { \
-    PyObject *module; \
-    PyObject *api; \
-    if (! (module = PyImport_ImportModule("Acquisition"))) return NULL; \
-    if (! (api = PyObject_GetAttrString(module,"AcquisitionCAPI"))) return NULL; \
-    Py_DECREF(module); \
-    AcquisitionCAPI = PyCObject_AsVoidPtr(api); \
-    Py_DECREF(api); \
+    AcquisitionCAPI = PyCapsule_Import("Acquisition.AcquisitionCAPI", 0); \
 }
 
 

--- a/include/ExtensionClass/ExtensionClass.h
+++ b/include/ExtensionClass/ExtensionClass.h
@@ -244,22 +244,4 @@ static PyExtensionClass NAME ## Type = { PyVarObject_HEAD_INIT(NULL, 0) # NAME, 
   ((PyExtensionClassCAPI != NULL) || \
    (PyExtensionClassCAPI = PyCapsule_Import("ExtensionClass.CAPI2", 0)))
 
-
-/* These are being overridded to use tp_free when used with
-   new-style classes. This is to allow old extention-class code
-   to work.
-*/
-
-#undef PyMem_DEL
-#undef PyObject_DEL
-
-#define PyMem_DEL(O)                                   \
-  if ((Py_TYPE(O)->tp_flags & Py_TPFLAGS_HAVE_CLASS) \
-      && (Py_TYPE(O)->tp_free != NULL))              \
-    Py_TYPE(O)->tp_free((PyObject*)(O));             \
-  else                                                 \
-    PyObject_FREE((O));
-
-#define PyObject_DEL(O) PyMem_DEL(O)
-
 #endif /* EXTENSIONCLASS_H */

--- a/setup.py
+++ b/setup.py
@@ -13,30 +13,21 @@
 ##############################################################################
 
 from os.path import join
-import platform
-import sys
 
 from setuptools import setup, find_packages, Extension
 
 README = open('README.rst').read()
 CHANGES = open('CHANGES.rst').read()
 
-# PyPy won't build the extension
-py_impl = getattr(platform, 'python_implementation', lambda: None)
-is_pypy = py_impl() == 'PyPy'
-py3k = sys.version_info >= (3, )
-if is_pypy or py3k:
-    ext_modules = []
-else:
-    ext_modules = [
-        Extension(
-            name='AccessControl.cAccessControl',
-            include_dirs=['include', 'src'],
-            sources=[join('src', 'AccessControl', 'cAccessControl.c')],
-            depends=[join('include', 'ExtensionClass', 'ExtensionClass.h'),
-                     join('include', 'ExtensionClass', '_compat.h'),
-                     join('include', 'Acquisition', 'Acquisition.h')]),
-    ]
+ext_modules = [
+    Extension(
+        name='AccessControl.cAccessControl',
+        include_dirs=['include', 'src'],
+        sources=[join('src', 'AccessControl', 'cAccessControl.c')],
+        depends=[join('include', 'ExtensionClass', 'ExtensionClass.h'),
+                 join('include', 'ExtensionClass', '_compat.h'),
+                 join('include', 'Acquisition', 'Acquisition.h')]),
+]
 
 setup(name='AccessControl',
       version='4.0a6.dev0',

--- a/src/AccessControl/Implementation.py
+++ b/src/AccessControl/Implementation.py
@@ -72,7 +72,8 @@ def setImplementation(name):
     _implementation_set = 1
 
 
-_default_implementation = None
+# start with the default, mostly because we need something for the tests
+_default_implementation = 'C'
 _implementation_name = None
 _implementation_set = 0
 
@@ -94,14 +95,6 @@ _policy_names = {
     "AccessControl.ZopeSecurityPolicy": ("ZopeSecurityPolicy",
                                          ),
 }
-
-# start with the default, mostly because we need something for the tests
-try:
-    from . import ImplC
-    _default_implementation = 'C'
-    del ImplC
-except ImportError:
-    _default_implementation = 'PYTHON'
 
 setImplementation(_default_implementation)
 

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -2260,6 +2260,7 @@ static struct PyModuleDef moduledef =
 
 static PyObject*
 module_init(void) {
+	PyObject *tmp;
 	PyObject *module;
 	PyObject *dict;
         PURE_MIXIN_CLASS(RestrictedDTMLMixin,
@@ -2313,45 +2314,45 @@ module_init(void) {
 	/*| from SimpleObjectPolicies import Containers
 	*/
 
-	IMPORT(module, "AccessControl.SimpleObjectPolicies");
-	GETATTR(module, Containers);
-	GETATTR(module, ContainerAssertions);
-	Py_DECREF(module);
-	module = NULL;
+	IMPORT(tmp, "AccessControl.SimpleObjectPolicies");
+	GETATTR(tmp, Containers);
+	GETATTR(tmp, ContainerAssertions);
+	Py_DECREF(tmp);
+	tmp = NULL;
 
 
 	/*| from ZopeSecurityPolicy import getRoles
 	*/
 
-	IMPORT(module, "AccessControl.ZopeSecurityPolicy");
-	GETATTR(module, getRoles);
-	Py_DECREF(module);
-	module = NULL;
+	IMPORT(tmp, "AccessControl.ZopeSecurityPolicy");
+	GETATTR(tmp, getRoles);
+	Py_DECREF(tmp);
+	tmp = NULL;
 
 
 	/*| from unauthorized import Unauthorized
 	*/
 
-	IMPORT(module, "AccessControl.unauthorized");
-	GETATTR(module, Unauthorized);
-	Py_DECREF(module);
-	module = NULL;
+	IMPORT(tmp, "AccessControl.unauthorized");
+	GETATTR(tmp, Unauthorized);
+	Py_DECREF(tmp);
+	tmp = NULL;
 
 	/*| from AccessControl.SecurityManagement import getSecurityManager
 	*/
 
-	IMPORT(module, "AccessControl.SecurityManagement");
-	GETATTR(module, getSecurityManager);
-	Py_DECREF(module);
-	module = NULL;
+	IMPORT(tmp, "AccessControl.SecurityManagement");
+	GETATTR(tmp, getSecurityManager);
+	Py_DECREF(tmp);
+	tmp = NULL;
 
 	/*| from logger_wrapper import warn
 	*/
 
-	IMPORT(module, "AccessControl.logger_wrapper");
-	GETATTR(module, warn);
-	Py_DECREF(module);
-	module = NULL;
+	IMPORT(tmp, "AccessControl.logger_wrapper");
+	GETATTR(tmp, warn);
+	Py_DECREF(tmp);
+	tmp = NULL;
 
   return module;
 }

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -1334,7 +1334,7 @@ static PyObject *ZopeSecurityPolicy_validate(PyObject *self, PyObject *args) {
 static void ZopeSecurityPolicy_dealloc(ZopeSecurityPolicy *self) {
 
        Py_DECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
-	PyObject_DEL(self);  
+    Py_TYPE(self)->tp_free((PyObject*) self);
 }
 
 
@@ -1418,7 +1418,7 @@ SecurityManager_dealloc(SecurityManager *self)
   Py_XDECREF(self->validate);
   Py_XDECREF(self->checkPermission);
   Py_DECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
-  PyObject_DEL(self);  
+  Py_TYPE(self)->tp_free((PyObject*) self);
 }
 
 static PyObject *
@@ -1635,7 +1635,7 @@ static void PermissionRole_dealloc(PermissionRole *self) {
 
 	Py_XDECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
 
-	PyObject_DEL(self);  
+    Py_TYPE(self)->tp_free((PyObject*) self);
 }
 
 
@@ -1788,7 +1788,7 @@ static void imPermissionRole_dealloc(imPermissionRole *self) {
 
 	Py_DECREF(Py_TYPE(self));	/* Extensionclass init incref'd */
 
-	PyObject_DEL(self);  
+    Py_TYPE(self)->tp_free((PyObject*) self);
 }
 
 /*

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -256,15 +256,12 @@ class PythonSecurityManagerTests(SecurityManagerTestBase,
         return SecurityManager
 
 
-try:
-    from AccessControl.ImplC import SecurityManager
-    # N.B.:  The C version mixes in the Python version, which is why we
-    #        can test for conformance to ISecurityManager.
-    class C_SecurityManagerTests(SecurityManagerTestBase,
-                                 ISecurityManagerConformance,
-                                 unittest.TestCase):
+class C_SecurityManagerTests(SecurityManagerTestBase,
+                             ISecurityManagerConformance,
+                             unittest.TestCase):
+    # The C version mixes in the Python version, which is why we
+    # can test for conformance to ISecurityManager.
 
-        def _getTargetClass(self):
-            return SecurityManager
-except ImportError:
-    pass
+    def _getTargetClass(self):
+        from AccessControl.ImplC import SecurityManager
+        return SecurityManager

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -28,14 +28,6 @@ try:
 except ImportError:
     import thread
 
-
-try:
-    from AccessControl import ImplC
-except ImportError:
-    HAVE_IMPLC = False
-else:
-    HAVE_IMPLC = True
-
 user_roles = ('RoleOfUser',)
 eo_roles = ('RoleOfExecutableOwner',)
 sysadmin_roles = ('RoleOfSysAdmin',)
@@ -440,15 +432,12 @@ class Python_ZSPTests(ZopeSecurityPolicyTestBase,
         return ZopeSecurityPolicy
 
 
-if HAVE_IMPLC:
-    class C_ZSPTests(ZopeSecurityPolicyTestBase,
-                     ISecurityPolicyConformance,
-                     ):
-        def _getTargetClass(self):
-            return ImplC.ZopeSecurityPolicy
-else:
-    class C_ZSPTests(unittest.TestCase):
-        pass
+class C_ZSPTests(ZopeSecurityPolicyTestBase,
+                 ISecurityPolicyConformance,
+                 ):
+    def _getTargetClass(self):
+        from AccessControl.ImplC import ZopeSecurityPolicy
+        return ZopeSecurityPolicy
 
 
 class SecurityManagerTestsBase(unittest.TestCase):
@@ -519,16 +508,13 @@ class Python_SMTests(SecurityManagerTestsBase):
         return ImplPython
 
 
-if HAVE_IMPLC:
-    class C_SMTests(SecurityManagerTestsBase):
+class C_SMTests(SecurityManagerTestsBase):
 
-        _implementation_name = "C"
+    _implementation_name = "C"
 
-        def _getModule(self):
-            return ImplC
-else:
-    class C_SMTests(unittest.TestCase):
-        pass
+    def _getModule(self):
+        from AccessControl import ImplC
+        return ImplC
 
 
 def test_getRoles():


### PR DESCRIPTION
This is a WIP branch / PR to get the AccessControl C extension to be Python 3 compatible (refs #36).

Currently the extension compiles, but the tests fail with a couple different errors, before segfaulting:
```
AttributeError: PyCapsule_Import "Acquisition.AcquisitionCAPI" is not valid
SystemError: NULL result without error in PyObject_Call
Segmentation fault: 11
```

My guess is that the ``module_init`` is pretty wrong. It reassigns the local `module` variable a couple of times and ends up returning `NULL` at the end. From my understanding this must return the module definition as returned by the first `module = PyModule_Create(&moduledef);` under Python 3.

There are probably more problems, as I've ported the rest of the code with my limited C understanding.

@stephan-hof, @tseaver Any help would be greatly appreciated :)