### PR TITLE
Preserve order of roles in userdefined_roles()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ For changes before version 3.0, see ``HISTORY.rst``.
 
 - Add icon for Bootstrap ZMI.
 
+- Fix order of roles returned by
+  ``AccessControl.rolemanager.RoleManager.userdefined_roles``.
+
 
 4.0b4 (2018-04-16)
 ------------------

--- a/src/AccessControl/rolemanager.py
+++ b/src/AccessControl/rolemanager.py
@@ -409,8 +409,9 @@ class RoleManager(Base, RoleManager):
     def userdefined_roles(self):
         """Return list of user-defined roles.
         """
-        default_roles = classattr(self.__class__, '__ac_roles__')
-        return tuple(set(self.__ac_roles__) - set(default_roles))
+        default_roles = set(classattr(self.__class__, '__ac_roles__'))
+        return tuple(
+            role for role in self.__ac_roles__ if role not in default_roles)
 
     def possible_permissions(self):
         d = {}

--- a/src/AccessControl/tests/testRole.py
+++ b/src/AccessControl/tests/testRole.py
@@ -129,6 +129,7 @@ class TestRoleManager(unittest.TestCase):
 
         # forcing our own roles
         root.context1.__ac_roles__ = ('Role2', 'Role1')
-        self.assertEqual(set(root.context1.userdefined_roles()),
-                         set(('Role1', 'Role2')))
-
+        self.assertEqual(
+            ('Role2', 'Role1'),
+            root.context1.userdefined_roles(),
+        )


### PR DESCRIPTION
This fixes a regression revealed by a test in Plone.