### PR TITLE
re #60: remove duplicate guard against * imports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ For changes before version 3.0, see ``HISTORY.rst``.
 
 - Add support for Python 3.7.
 
+- Remove duplicate guard against * imports. (#60)
+
 4.0b4 (2018-04-16)
 ------------------
 

--- a/src/AccessControl/ZopeGuards.py
+++ b/src/AccessControl/ZopeGuards.py
@@ -390,8 +390,6 @@ def guarded_import(mname, globals=None, locals=None, fromlist=None,
                    level=import_default_level):
     if fromlist is None:
         fromlist = ()
-    if '*' in fromlist:
-        raise Unauthorized("'from %s import *' is not allowed")
     if globals is None:
         globals = {}
     if locals is None:
@@ -406,8 +404,6 @@ def guarded_import(mname, globals=None, locals=None, fromlist=None,
     module = load_module(None, None, mnameparts, validate, globals, locals)
     if module is None:
         raise Unauthorized("import of '%s' is unauthorized" % mname)
-    if fromlist is None:
-        fromlist = ()
     for name in fromlist:
         v = getattr(module, name, None)
         if v is None:

--- a/src/AccessControl/tests/testModuleSecurity.py
+++ b/src/AccessControl/tests/testModuleSecurity.py
@@ -67,9 +67,6 @@ class ModuleSecurityTests(unittest.TestCase):
         self.assertAuth('AccessControl.tests.public_module.submodule',
                         ('pub',))
 
-    def test_star_import_not_allowed(self):
-        self.assertUnauth('AccessControl.tests.public_module', ('*',))
-
     def test_public_module_asterisk_not_allowed(self):
         self.assertUnauth('AccessControl.tests.public_module', ('*',))
 

--- a/src/AccessControl/tests/testModuleSecurity.py
+++ b/src/AccessControl/tests/testModuleSecurity.py
@@ -67,6 +67,9 @@ class ModuleSecurityTests(unittest.TestCase):
         self.assertAuth('AccessControl.tests.public_module.submodule',
                         ('pub',))
 
+    def test_star_import_not_allowed(self):
+        self.assertUnauth('AccessControl.tests.public_module', ('*',))
+
     def test_public_module_asterisk_not_allowed(self):
         self.assertUnauth('AccessControl.tests.public_module', ('*',))
 


### PR DESCRIPTION
Contrary to the ticket rationale, this doesn't even rely on a guard in a
current enough version of RestrictedPython as even SecurityManager.validate
will raise Unauthorized if '*' is in the from-list.

fixes #60 