### PR TITLE
Enable Python 3.7 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
     - python: 35-x64
     - python: 36
     - python: 36-x64
+    - python: 37
+    - python: 37-x64
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"


### PR DESCRIPTION
Python 3.7 is already enabled on all the other platforms.