### PR TITLE
PY3: iteration over "dict.{keys,values,items}" result

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ For changes before version 3.0, see ``HISTORY.rst``.
 4.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- PY3: allow iteration over the result of ``dict.{keys,values,items}``
+  (`#89 <https://github.com/zopefoundation/AccessControl/issues/89>`_).
 
 
 4.0 (2019-05-08)

--- a/src/AccessControl/ZopeGuards.py
+++ b/src/AccessControl/ZopeGuards.py
@@ -34,6 +34,7 @@ from AccessControl.SecurityInfo import secureModule
 from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.SimpleObjectPolicies import ContainerAssertions
 from AccessControl.SimpleObjectPolicies import Containers
+from AccessControl.SimpleObjectPolicies import allow_type
 
 
 _marker = []  # Create a new marker object.
@@ -194,6 +195,13 @@ def _check_dict_access(name, value):
 
 
 ContainerAssertions[type({})] = _check_dict_access
+
+
+if six.PY3:
+    # Allow iteration over the result of `dict.{keys, values, items}`
+    d = {}
+    for attr in ("keys", "values", "items"):
+        allow_type(type(getattr(d, attr)()))
 
 
 _list_white_list = {

--- a/src/AccessControl/tests/testZopeGuards.py
+++ b/src/AccessControl/tests/testZopeGuards.py
@@ -355,6 +355,14 @@ class TestDictGuards(GuardTestCase):
             self.setSecurityManager(old)
         self.assertTrue(sm.calls)
 
+    def test_kvi_iteration(self):
+        from AccessControl.ZopeGuards import SafeIter
+        d = dict(a=1, b=2)
+        for attr in ("keys", "values", "items"):
+            v = getattr(d, attr)()
+            si = SafeIter(v)
+            self.assertEqual(next(si), next(iter(v)))
+
 
 class TestListGuards(GuardTestCase):
 


### PR DESCRIPTION
Fixes #89 (and https://github.com/zopefoundation/Products.PythonScripts/issues/35).