### PR TITLE
Update to the isort > 5.0.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ known_zope = RestrictedPython. zExceptions
 known_localfolder = AccessControl
 line_length = 79
 lines_after_imports = 2
-not_skip =
-    __init__.py
 
 [flake8]
 no-accept-encodings = True

--- a/src/AccessControl/Implementation.py
+++ b/src/AccessControl/Implementation.py
@@ -50,9 +50,9 @@ def setImplementation(name):
     if name == _implementation_name:
         return
     if name == "C":
-        from AccessControl import ImplC as impl  # NOQA
+        from AccessControl import ImplC as impl
     elif name == "PYTHON":
-        from AccessControl import ImplPython as impl  # NOQA
+        from AccessControl import ImplPython as impl
     else:
         raise ValueError("unknown policy implementation: %r" % name)
 

--- a/src/AccessControl/requestmethod.py
+++ b/src/AccessControl/requestmethod.py
@@ -22,6 +22,7 @@ if six.PY3:
     from inspect import signature
 else:  # Python 2
     from inspect import getargspec as getfullargspec
+
     from funcsigs import signature
 
 _default = []

--- a/src/AccessControl/tests/testClassSecurityInfo.py
+++ b/src/AccessControl/tests/testClassSecurityInfo.py
@@ -43,8 +43,9 @@ class ClassSecurityInfoTests(unittest.TestCase):
 
     def test_SetPermissionDefault(self):
         # Test setting default roles for permissions.
-        from AccessControl.class_init import InitializeClass
         from ExtensionClass import Base
+
+        from AccessControl.class_init import InitializeClass
 
         ClassSecurityInfo = self._getTargetClass()
 
@@ -127,8 +128,9 @@ class ClassSecurityInfoTests(unittest.TestCase):
                          [('Make food', (), ('Chef',))])
 
     def test_EnsureProtectedDecoCall(self):
-        from AccessControl.class_init import InitializeClass
         from ExtensionClass import Base
+
+        from AccessControl.class_init import InitializeClass
 
         ClassSecurityInfo = self._getTargetClass()
 

--- a/src/AccessControl/tests/testModuleSecurity.py
+++ b/src/AccessControl/tests/testModuleSecurity.py
@@ -38,6 +38,7 @@ class ModuleSecurityTests(unittest.TestCase):
 
     def assertUnauth(self, module, fromlist, level=import_default_level):
         from zExceptions import Unauthorized
+
         from AccessControl.ZopeGuards import guarded_import
         self.assertRaises(Unauthorized, guarded_import, module,
                           fromlist=fromlist, level=level)

--- a/src/AccessControl/tests/testOwned.py
+++ b/src/AccessControl/tests/testOwned.py
@@ -82,8 +82,9 @@ class OwnedTests(unittest.TestCase):
         return Dummy(*args, **kw)
 
     def test_interfaces(self):
-        from AccessControl.interfaces import IOwned
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import IOwned
 
         verifyClass(IOwned, Owned)
 

--- a/src/AccessControl/tests/testPermissionMapping.py
+++ b/src/AccessControl/tests/testPermissionMapping.py
@@ -4,8 +4,9 @@ import unittest
 class TestRoleManager(unittest.TestCase):
 
     def test_interfaces(self):
+        from zope.interface.verify import verifyClass
+
         from AccessControl.interfaces import IPermissionMappingSupport
         from AccessControl.PermissionMapping import RoleManager
-        from zope.interface.verify import verifyClass
 
         verifyClass(IPermissionMappingSupport, RoleManager)

--- a/src/AccessControl/tests/testRole.py
+++ b/src/AccessControl/tests/testRole.py
@@ -2,9 +2,10 @@ import unittest
 
 
 def _makeRootAndUser():
-    from AccessControl.rolemanager import RoleManager
-    from Acquisition import Implicit
     from Acquisition import Explicit
+    from Acquisition import Implicit
+
+    from AccessControl.rolemanager import RoleManager
 
     class DummyContext(Implicit, RoleManager):
         __roles__ = ('Manager',)
@@ -46,9 +47,10 @@ class TestRoleManager(unittest.TestCase):
         noSecurityManager()
 
     def test_interfaces(self):
+        from zope.interface.verify import verifyClass
+
         from AccessControl.interfaces import IRoleManager
         from AccessControl.rolemanager import RoleManager
-        from zope.interface.verify import verifyClass
 
         verifyClass(IRoleManager, RoleManager)
 

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -54,8 +54,9 @@ class ExecutableObject:
 class ISecurityManagerConformance:
 
     def test_conforms_to_ISecurityManager(self):
-        from AccessControl.interfaces import ISecurityManager
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import ISecurityManager
         verifyClass(ISecurityManager, self._getTargetClass())
 
 

--- a/src/AccessControl/tests/testZCML.py
+++ b/src/AccessControl/tests/testZCML.py
@@ -96,6 +96,7 @@ class TestSecurity(unittest.TestCase):
 
     def tearDown(self):
         from zope.component.testing import tearDown
+
         from AccessControl.security import clearSecurityInfo
         clearSecurityInfo(Dummy1)
         clearSecurityInfo(Dummy2)
@@ -113,15 +114,17 @@ class TestSecurity(unittest.TestCase):
         # declarations and ``Dummy1`` does not.  Before we do anything, none
         # of them have security access controls:
 
-        from AccessControl.tests.testZCML import Dummy1, Dummy2
+        from AccessControl.tests.testZCML import Dummy1
+        from AccessControl.tests.testZCML import Dummy2
         self.assertFalse(hasattr(Dummy1, '__ac_permissions__'))
         self.assertFalse(hasattr(Dummy2, '__ac_permissions__'))
 
         # Before we can make security declarations through ZCML, we need to
         # register the directive and the permission:
 
-        import AccessControl
         from zope.configuration.xmlconfig import XMLConfig
+
+        import AccessControl
         XMLConfig('meta.zcml', AccessControl)()
         XMLConfig('permissions.zcml', AccessControl)()
 
@@ -158,9 +161,9 @@ class TestSecurity(unittest.TestCase):
 
         # Now we look at the individual permissions:
 
-        from AccessControl.ZopeSecurityPolicy import getRoles
-        from AccessControl import ACCESS_PUBLIC
         from AccessControl import ACCESS_PRIVATE
+        from AccessControl import ACCESS_PUBLIC
+        from AccessControl.ZopeSecurityPolicy import getRoles
 
         dummy1 = Dummy1()
         self.assertEqual(

--- a/src/AccessControl/tests/testZopeGuards.py
+++ b/src/AccessControl/tests/testZopeGuards.py
@@ -64,8 +64,8 @@ class SecurityManager:
 class GuardTestCase(unittest.TestCase):
 
     def setSecurityManager(self, manager):
-        from AccessControl.SecurityManagement import get_ident
         from AccessControl.SecurityManagement import _managers
+        from AccessControl.SecurityManagement import get_ident
         key = get_ident()
         old = _managers.get(key)
         if manager is None:
@@ -123,8 +123,8 @@ class TestGuardedGetattr(GuardTestCase):
 
     def test_attr_handler_table(self):
         from AccessControl import Unauthorized
-        from AccessControl.ZopeGuards import guarded_getattr
         from AccessControl.SimpleObjectPolicies import ContainerAssertions
+        from AccessControl.ZopeGuards import guarded_getattr
         d = {}
         _dict = type(d)
         old = ContainerAssertions.get(_dict)
@@ -679,8 +679,8 @@ class TestActualPython(GuardTestCase):
         del self._wrapped_dicts
 
     def _initPolicyAndManager(self, manager=None):
-        from AccessControl.SecurityManagement import get_ident
         from AccessControl.SecurityManagement import _managers
+        from AccessControl.SecurityManagement import get_ident
         from AccessControl.SecurityManagement import newSecurityManager
         from AccessControl.SecurityManager import setSecurityPolicy
         from AccessControl.ZopeSecurityPolicy import ZopeSecurityPolicy
@@ -722,9 +722,10 @@ class TestActualPython(GuardTestCase):
             setSecurityPolicy(self._old_policy)
 
     def _getProtectedBaseClass(self):
+        from ExtensionClass import Base
+
         from AccessControl.class_init import InitializeClass
         from AccessControl.SecurityInfo import ClassSecurityInfo
-        from ExtensionClass import Base
 
         global _ProtectedBase
         if _ProtectedBase is None:
@@ -914,7 +915,9 @@ printed  # Prevent a warning of RestrictedPython that itis not used.
 
     def _compile_str(self, text, name):
         from RestrictedPython import compile_restricted
-        from AccessControl.ZopeGuards import get_safe_globals, guarded_getattr
+
+        from AccessControl.ZopeGuards import get_safe_globals
+        from AccessControl.ZopeGuards import guarded_getattr
 
         code = compile_restricted(text, name, 'exec')
 

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -354,10 +354,12 @@ class ZopeSecurityPolicyTestBase(unittest.TestCase):
         self.assertTrue(v, '_View_Permission should grant access to theowner')
 
     def testContainersContextManager(self):
-        from AccessControl.SimpleObjectPolicies import override_containers
+        from types import TracebackType
+
         from AccessControl.SimpleObjectPolicies import ContainerAssertions
         from AccessControl.SimpleObjectPolicies import Containers
-        from types import TracebackType
+        from AccessControl.SimpleObjectPolicies import override_containers
+
         # Surely we have no assertions for this type:
         self.assertNotIn(TracebackType, ContainerAssertions)
         with override_containers(TracebackType, 1):
@@ -383,6 +385,7 @@ class ZopeSecurityPolicyTestBase(unittest.TestCase):
             'aq_inner': 1,
         }
         from AccessControl.SimpleObjectPolicies import override_containers
+
         # By default we allow all access to str, but this may have been
         # overridden to disallow some access of str.format.  So we temporarily
         # restore the default of allowing all access.
@@ -426,6 +429,7 @@ class ZopeSecurityPolicyTestBase(unittest.TestCase):
     def testUnicodeName(self):
         policy = self.policy
         from AccessControl.SimpleObjectPolicies import override_containers
+
         # By default we allow all access to str, but this may have been
         # overridden to disallow some access of str.format.  So we temporarily
         # restore the default of allowing all access.
@@ -455,8 +459,9 @@ class ZopeSecurityPolicyTestBase(unittest.TestCase):
 class ISecurityPolicyConformance:
 
     def test_conforms_to_ISecurityPolicy(self):
-        from AccessControl.interfaces import ISecurityPolicy
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import ISecurityPolicy
         verifyClass(ISecurityPolicy, self._getTargetClass())
 
 

--- a/src/AccessControl/tests/test_safe_formatter.py
+++ b/src/AccessControl/tests/test_safe_formatter.py
@@ -77,6 +77,7 @@ class FormatterTest(unittest.TestCase):
 
     def test_prevents_bad_string_formatting_attribute(self):
         from AccessControl.safe_formatter import SafeFormatter
+
         # Accessing basic Python attributes on a basic Python type is fine.
         formatted = SafeFormatter('{0.upper}').safe_format('foo')
         self.assertTrue(formatted.startswith('<built-in method upper'))
@@ -97,6 +98,7 @@ class FormatterTest(unittest.TestCase):
 
     def test_prevents_bad_unicode_formatting_attribute(self):
         from AccessControl.safe_formatter import SafeFormatter
+
         # Accessing basic Python attributes on a basic Python type is fine.
         formatted = SafeFormatter(u'{0.upper}').safe_format('foo')
         self.assertTrue(formatted.startswith('<built-in method upper'))
@@ -117,6 +119,7 @@ class FormatterTest(unittest.TestCase):
 
     def test_prevents_bad_string_formatting_item(self):
         from AccessControl.safe_formatter import SafeFormatter
+
         # Accessing basic Python types in a basic Python dict is fine.
         foo = {'bar': 'Can you see me?'}
         self.assertEqual(SafeFormatter('{0[bar]}').safe_format(foo),
@@ -135,6 +138,7 @@ class FormatterTest(unittest.TestCase):
 
     def test_prevents_bad_unicode_formatting_item(self):
         from AccessControl.safe_formatter import SafeFormatter
+
         # Accessing basic Python types in a basic Python dict is fine.
         foo = {'bar': 'Can you see me?'}
         self.assertEqual(SafeFormatter(u'{0[bar]}').safe_format(foo),
@@ -152,9 +156,11 @@ class FormatterTest(unittest.TestCase):
                           folder)
 
     def test_prevents_bad_string_formatting_key(self):
+        from persistent.list import PersistentList
+
         from AccessControl.safe_formatter import SafeFormatter
         from AccessControl.ZopeGuards import guarded_getitem
-        from persistent.list import PersistentList
+
         # Accessing basic Python types in a basic Python list is fine.
         foo = list(['bar'])
         self.assertEqual(SafeFormatter('{0[0]}').safe_format(foo),
@@ -184,6 +190,7 @@ class FormatterTest(unittest.TestCase):
 
     def test_prevents_bad_unicode_formatting_key(self):
         from AccessControl.safe_formatter import SafeFormatter
+
         # Accessing basic Python types in a basic Python list is fine.
         foo = list(['bar'])
         self.assertEqual(SafeFormatter('{0[0]}').safe_format(foo),

--- a/src/AccessControl/tests/test_tainted.py
+++ b/src/AccessControl/tests/test_tainted.py
@@ -21,9 +21,9 @@ import six
 class TestFunctions(unittest.TestCase):
 
     def test_taint_string(self):
-        from AccessControl.tainted import taint_string
-        from AccessControl.tainted import TaintedString
         from AccessControl.tainted import TaintedBytes
+        from AccessControl.tainted import TaintedString
+        from AccessControl.tainted import taint_string
         self.assertIsInstance(taint_string('string'), TaintedString)
         self.assertIsInstance(taint_string(b'bytes'), TaintedBytes)
 

--- a/src/AccessControl/tests/test_userfolder.py
+++ b/src/AccessControl/tests/test_userfolder.py
@@ -29,6 +29,7 @@ class UserFolderTests(unittest.TestCase):
 
     def tearDown(self):
         import transaction
+
         from AccessControl.SecurityManagement import noSecurityManager
         noSecurityManager()
         transaction.abort()
@@ -53,8 +54,9 @@ class UserFolderTests(unittest.TestCase):
         newSecurityManager(None, user)
 
     def test_class_conforms_to_IStandardUserFolder(self):
-        from AccessControl.interfaces import IStandardUserFolder
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import IStandardUserFolder
         verifyClass(IStandardUserFolder, self._getTargetClass())
 
     def testGetUser(self):

--- a/src/AccessControl/tests/test_users.py
+++ b/src/AccessControl/tests/test_users.py
@@ -25,8 +25,9 @@ class BasicUserTests(unittest.TestCase):
         return self._getTargetClass()(name, password, roles, domains)
 
     def test_interfaces(self):
-        from AccessControl.interfaces import IUser
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import IUser
 
         verifyClass(IUser, self._getTargetClass())
 
@@ -493,8 +494,9 @@ class SimpleUserTests(unittest.TestCase):
         return self._getTargetClass()(name, password, roles, domains)
 
     def test_interfaces(self):
-        from AccessControl.interfaces import IUser
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import IUser
 
         verifyClass(IUser, self._getTargetClass())
 
@@ -532,8 +534,9 @@ class SpecialUserTests(unittest.TestCase):
         return self._getTargetClass()(name, password, roles, domains)
 
     def test_interfaces(self):
-        from AccessControl.interfaces import IUser
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import IUser
 
         verifyClass(IUser, self._getTargetClass())
 
@@ -563,8 +566,9 @@ class UnrestrictedUserTests(unittest.TestCase):
         return self._getTargetClass()(name, password, roles, domains)
 
     def test_interfaces(self):
-        from AccessControl.interfaces import IUser
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import IUser
 
         verifyClass(IUser, self._getTargetClass())
 
@@ -614,8 +618,9 @@ class NullUnrestrictedUserTests(unittest.TestCase):
         return self._getTargetClass()()
 
     def test_interfaces(self):
-        from AccessControl.interfaces import IUser
         from zope.interface.verify import verifyClass
+
+        from AccessControl.interfaces import IUser
 
         verifyClass(IUser, self._getTargetClass())
 

--- a/tox.ini
+++ b/tox.ini
@@ -40,11 +40,11 @@ basepython = python3.6
 commands_pre =
     mkdir -p {toxinidir}/parts/lint
 commands =
-    isort --check-only --diff --recursive {toxinidir}/src setup.py
+    isort --check-only --diff {toxinidir}/src setup.py
     - flake8 --format=html src setup.py
     flake8 src setup.py
 deps =
-    isort
+    isort > 5.0
     flake8
     # helper to generate HTML reports:
     flake8-html


### PR DESCRIPTION
This current version also sorts imports inside of function definitions.

This diff seems small enough to be introduced before the changes by other issues. 