### PR TITLE
Add deprecation warnings for BBB imports.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,13 @@ For changes before version 3.0, see ``HISTORY.rst``.
 4.3 (unreleased)
 ----------------
 
+- Add deprecation warnings for BBB imports in:
+
+  + ``AccessControl/AuthEncoding.py``
+  + ``AccessControl/Owned.py``
+  + ``AccessControl/Role.py``
+  + ``AccessControl/User.py``
+
 
 4.2 (2020-04-20)
 ----------------

--- a/src/AccessControl/AuthEncoding.py
+++ b/src/AccessControl/AuthEncoding.py
@@ -11,24 +11,37 @@
 #
 ##############################################################################
 
-from __future__ import absolute_import
-
-# BBB
-from AuthEncoding.AuthEncoding import MySQLDigestScheme  # NOQA
-from AuthEncoding.AuthEncoding import PasswordEncryptionScheme
-from AuthEncoding.AuthEncoding import SHADigestScheme
-from AuthEncoding.AuthEncoding import SSHADigestScheme
-from AuthEncoding.AuthEncoding import constant_time_compare
-from AuthEncoding.AuthEncoding import is_encrypted
-from AuthEncoding.AuthEncoding import listSchemes
-from AuthEncoding.AuthEncoding import pw_encode
-from AuthEncoding.AuthEncoding import pw_encrypt
-from AuthEncoding.AuthEncoding import pw_validate
-from AuthEncoding.AuthEncoding import registerScheme
+import AuthEncoding.AuthEncoding
+from zope.deferredimport import deprecated
 
 
-# Bogosity on various platforms due to ITAR restrictions
-try:
-    from AuthEncoding.AuthEncoding import CryptDigestScheme  # NOQA
-except ImportError:
-    pass
+deprecated(
+    "The functionality of AccessControl.AuthEncoding has moved to"
+    " AuthEncoding.AuthEncoding. Please import from there."
+    " This backward compatibility shim will be removed in AccessControl"
+    " version 6.",
+    MySQLDigestScheme='AuthEncoding.AuthEncoding:MySQLDigestScheme',
+    PasswordEncryptionScheme='AuthEncoding.AuthEncoding:PasswordEncryptionScheme',  # noqa
+    SHADigestScheme='AuthEncoding.AuthEncoding:SHADigestScheme',
+    SSHADigestScheme='AuthEncoding.AuthEncoding:SSHADigestScheme',
+    constant_time_compare='AuthEncoding.AuthEncoding:constant_time_compare',
+    is_encrypted='AuthEncoding.AuthEncoding:is_encrypted',
+    listSchemes='AuthEncoding.AuthEncoding:listSchemes',
+    pw_encode='AuthEncoding.AuthEncoding:pw_encode',
+    pw_encrypt='AuthEncoding.AuthEncoding:pw_encrypt',
+    pw_validate='AuthEncoding.AuthEncoding:pw_validate',
+    registerScheme='AuthEncoding.AuthEncoding:registerScheme',
+)
+
+# Bogosity on various platforms due to ITAR restrictions.
+# We need to import the module anyway to check for the presence of
+# restrictions, but do want to silence the ImportError.
+
+if hasattr(AuthEncoding.AuthEncoding, 'CryptDigestScheme'):
+    deprecated(
+        "The functionality of AccessControl.AuthEncoding has moved to"
+        " AuthEncoding.AuthEncoding. Please import from there."
+        " This backward compatibility shim will be removed in AccessControl"
+        " version 6.",
+        CryptDigestScheme='AuthEncoding.AuthEncoding:CryptDigestScheme',
+    )

--- a/src/AccessControl/AuthEncoding.py
+++ b/src/AccessControl/AuthEncoding.py
@@ -11,6 +11,8 @@
 #
 ##############################################################################
 
+from __future__ import absolute_import
+
 import AuthEncoding.AuthEncoding
 from zope.deferredimport import deprecated
 

--- a/src/AccessControl/Owned.py
+++ b/src/AccessControl/Owned.py
@@ -15,14 +15,19 @@
 
 from zope.deferredimport import deprecated
 
-# BBB
-from AccessControl.owner import EditUnowned
-from AccessControl.owner import EmergencyUserCannotOwn
-from AccessControl.owner import UnownableOwner
-from AccessControl.owner import absattr
-from AccessControl.owner import ownableFilter
-from AccessControl.owner import ownerInfo
 
+deprecated(
+    "The functionality of AccessControl.Owned has moved to"
+    " AccessControl.owner. Please import from there."
+    " This backward compatibility shim will be removed in AccessControl"
+    " version 6.",
+    EditUnowned='AccessControl.owner:EditUnowned',
+    EmergencyUserCannotOwn='AccessControl.owner:EmergencyUserCannotOwn',
+    UnownableOwner='AccessControl.owner:UnownableOwner',
+    absattr='AccessControl.owner:absattr',
+    ownableFilter='AccessControl.owner:ownableFilter',
+    ownerInfo='AccessControl.owner:ownerInfo',
+)
 
 deprecated(
     "The Owned class has moved to OFS.owner. This compatibility "

--- a/src/AccessControl/Role.py
+++ b/src/AccessControl/Role.py
@@ -15,18 +15,23 @@
 
 from zope.deferredimport import deprecated
 
-# BBB
-from AccessControl.rolemanager import DEFAULTMAXLISTUSERS
-from AccessControl.rolemanager import _isBeingUsedAsAMethod
-from AccessControl.rolemanager import _isNotBeingUsedAsAMethod
-from AccessControl.rolemanager import class_attrs
-from AccessControl.rolemanager import class_dict
-from AccessControl.rolemanager import classattr
-from AccessControl.rolemanager import gather_permissions
-from AccessControl.rolemanager import instance_attrs
-from AccessControl.rolemanager import instance_dict
-from AccessControl.rolemanager import reqattr
 
+deprecated(
+    "The functionality of AccessControl.Role has moved to"
+    " AccessControl.rolemanager. Please import from there."
+    " This backward compatibility shim will be removed in AccessControl"
+    " version 6.",
+    DEFAULTMAXLISTUSERS='AccessControl.rolemanager:DEFAULTMAXLISTUSERS',
+    _isBeingUsedAsAMethod='AccessControl.rolemanager:_isBeingUsedAsAMethod',
+    _isNotBeingUsedAsAMethod='AccessControl.rolemanager:_isNotBeingUsedAsAMethod',  # noqa
+    class_attrs='AccessControl.rolemanager:class_attrs',
+    class_dict='AccessControl.rolemanager:class_dict',
+    classattr='AccessControl.rolemanager:classattr',
+    gather_permissions='AccessControl.rolemanager:gather_permissions',
+    instance_attrs='AccessControl.rolemanager:instance_attrs',
+    instance_dict='AccessControl.rolemanager:instance_dict',
+    reqattr='AccessControl.rolemanager:reqattr',
+)
 
 deprecated(
     "RoleManager has moved to OFS.role. Please "

--- a/src/AccessControl/User.py
+++ b/src/AccessControl/User.py
@@ -15,28 +15,31 @@
 
 from zope.deferredimport import deprecated
 
-# BBB
-from AccessControl.users import BasicUser
-from AccessControl.users import NullUnrestrictedUser
-from AccessControl.users import SimpleUser
-from AccessControl.users import SpecialUser
-from AccessControl.users import UnrestrictedUser as Super
-from AccessControl.users import User
-from AccessControl.users import _remote_user_mode
-from AccessControl.users import absattr
-from AccessControl.users import addr_match
-from AccessControl.users import domainSpecMatch
-from AccessControl.users import emergency_user
-from AccessControl.users import host_match
-from AccessControl.users import nobody
-from AccessControl.users import readUserAccessFile
-from AccessControl.users import reqattr
-from AccessControl.users import rolejoin
-from AccessControl.users import system
 
-
-from AccessControl.users import UnrestrictedUser # noqa isort:skip
-
+deprecated(
+    "The functionality of AccessControl.User has moved to"
+    " AccessControl.users. Please import from there."
+    " This backward compatibility shim will be removed in AccessControl"
+    " version 6.",
+    BasicUser='AccessControl.users:BasicUser',
+    NullUnrestrictedUser='AccessControl.users:NullUnrestrictedUser',
+    SimpleUser='AccessControl.users:SimpleUser',
+    SpecialUser='AccessControl.users:SpecialUser',
+    Super='AccessControl.users:UnrestrictedUser',
+    UnrestrictedUser='AccessControl.users:UnrestrictedUser',
+    User='AccessControl.users:User',
+    _remote_user_mode='AccessControl.users:_remote_user_mode',
+    absattr='AccessControl.users:absattr',
+    addr_match='AccessControl.users:addr_match',
+    domainSpecMatch='AccessControl.users:domainSpecMatch',
+    emergency_user='AccessControl.users:emergency_user',
+    host_match='AccessControl.users:host_match',
+    nobody='AccessControl.users:nobody',
+    readUserAccessFile='AccessControl.users:readUserAccessFile',
+    reqattr='AccessControl.users:reqattr',
+    rolejoin='AccessControl.users:rolejoin',
+    system='AccessControl.users:system',
+)
 
 deprecated(
     "The standard Zope user folder implementation has moved to "

--- a/src/AccessControl/tests/test_userfolder.py
+++ b/src/AccessControl/tests/test_userfolder.py
@@ -148,7 +148,7 @@ class UserFolderTests(unittest.TestCase):
 
     def test__doAddUser_with_not_yet_encrypted_passwords(self):
         # See collector #1869 && #1926
-        from AccessControl.AuthEncoding import pw_validate
+        from AuthEncoding.AuthEncoding import pw_validate
 
         USER_ID = 'not_yet_encrypted'
         PASSWORD = 'password'
@@ -164,7 +164,7 @@ class UserFolderTests(unittest.TestCase):
 
     def test__doAddUser_with_preencrypted_passwords(self):
         # See collector #1869 && #1926
-        from AccessControl.AuthEncoding import pw_validate
+        from AuthEncoding.AuthEncoding import pw_validate
 
         USER_ID = 'already_encrypted'
         PASSWORD = 'password'

--- a/src/AccessControl/userfolder.py
+++ b/src/AccessControl/userfolder.py
@@ -23,13 +23,13 @@ import six
 from Acquisition import Implicit
 from Acquisition import aq_base
 from Acquisition import aq_parent
+from AuthEncoding import AuthEncoding
 from Persistence import Persistent
 from Persistence import PersistentMapping
 from zExceptions import BadRequest
 from zExceptions import Unauthorized
 from zope.interface import implementer
 
-from AccessControl import AuthEncoding
 from AccessControl import ClassSecurityInfo
 from AccessControl.class_init import InitializeClass
 from AccessControl.interfaces import IStandardUserFolder

--- a/src/AccessControl/users.py
+++ b/src/AccessControl/users.py
@@ -19,10 +19,10 @@ import socket
 
 from Acquisition import Implicit
 from Acquisition import aq_inContextOf
+from AuthEncoding import AuthEncoding
 from Persistence import Persistent
 from zope.interface import implementer
 
-from AccessControl import AuthEncoding
 from AccessControl import SpecialUsers
 from AccessControl.interfaces import IUser
 from AccessControl.PermissionRole import _what_not_even_god_should_do

--- a/src/AccessControl/users.py
+++ b/src/AccessControl/users.py
@@ -13,6 +13,8 @@
 """Access control package.
 """
 
+from __future__ import absolute_import
+
 import os
 import re
 import socket


### PR DESCRIPTION
This adds deprecation warnings for BBB imports. I declared version 6.0 as last version to support them. If we agree, that 5 is also enough I am happy to change that. 