### PR TITLE
Provide `AccessControl.get_safe_globals` to facilitate safe setup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ For changes before version 3.0, see ``HISTORY.rst``.
 5.3 (unreleased)
 ----------------
 
+- Provide ``AccessControl.get_safe_globals`` to facilitate safe use.
+
+
 
 5.2 (2021-07-30)
 ----------------
@@ -16,8 +19,6 @@ For changes before version 3.0, see ``HISTORY.rst``.
 5.1 (2021-07-30)
 ----------------
 NOTE: This release has been yanked from PyPI due to wheel build issues.
-
-- Provide ``AccessControl.get_safe_globals`` to facilitate safe use.
 
 - Fix a remote code execution issue by preventing access to
   ``string.Formatter`` from restricted code.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ For changes before version 3.0, see ``HISTORY.rst``.
 5.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Provide ``AccessControl.get_safe_globals`` to facilitate safe use.
 
 
 5.0 (2020-10-07)

--- a/src/AccessControl/ZopeGuards.py
+++ b/src/AccessControl/ZopeGuards.py
@@ -67,6 +67,7 @@ def initialize(impl):
     global guarded_getattr
     guarded_getattr = impl.guarded_getattr
     safe_builtins['getattr'] = guarded_getattr
+    _safe_globals['_getattr_'] = guarded_getattr
 
 
 def guarded_hasattr(object, name):

--- a/src/AccessControl/__init__.py
+++ b/src/AccessControl/__init__.py
@@ -29,6 +29,7 @@ from AccessControl.SecurityManagement import getSecurityManager
 from AccessControl.SecurityManagement import setSecurityPolicy
 from AccessControl.SimpleObjectPolicies import allow_type
 from AccessControl.unauthorized import Unauthorized
+from AccessControl.ZopeGuards import get_safe_globals
 from AccessControl.ZopeGuards import full_write_guard
 from AccessControl.ZopeGuards import safe_builtins
 


### PR DESCRIPTION
Analyzing a potential security risk, I came to the following code:
```python
from RestrictedPython import compile_restricted
import AccessControl.users
from AccessControl.ZopeGuards import get_safe_globals

glbs = get_safe_globals()

src = """
import AccessControl
x = AccessControl.users
"""

lcs = dict()
c = compile_restricted(src)
exec(c, glbs, lcs)
lcs
```
Surprisingly, the execution did not raise `UnAuthorized`: apparently, access to `AccessControl.users` has been granted.

The analysis revealed, that `get_safe_globals` does not return a dict which can safely be used as  globals for `exec` - despite its name. It contains the `_getattr_` from `RestrictedPython` and not that from `AccessControl` and therefore its use does not apply the `AccessControl` access policy.

This PR ensures that the dict returned by `ZopeGuards.get_safe_globals` contains the `_getattr_` from `AccessControl` and thereby makes it safe to be used as `eval/exec` argument. It also makes the function available from `AccessControl`.