### PR TITLE
Use `PURE_PYTHON` to switch default implementation to python.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - 2.7
@@ -171,6 +172,7 @@ jobs:
     needs: build-package
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - 2.7
@@ -231,7 +233,7 @@ jobs:
           python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Run tests without C extensions
         run: |
-          AC_PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+          PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Report Coverage
         run: |
           coverage combine

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,11 +229,9 @@ jobs:
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |
           python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
-# This is not supported
-#      - name: Run tests without C extensions
-#        run:
-#          # coverage makes PyPy run about 3x slower!
-#          PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+       - name: Run tests without C extensions
+         run:
+         AC_PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Report Coverage
         run: |
           coverage combine

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,9 +229,9 @@ jobs:
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |
           python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
-       - name: Run tests without C extensions
-         run:
-         AC_PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+      - name: Run tests without C extensions
+        run: |
+          AC_PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Report Coverage
         run: |
           coverage combine

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ For changes before version 3.0, see ``HISTORY.rst``.
 
 - Provide ``AccessControl.get_safe_globals`` to facilitate safe use.
 
+- Use ``AC_PURE_PYTHON`` as switch to enable python implementation as default.
+  This should not be used except for tests and debugging.
 
 
 5.2 (2021-07-30)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,8 @@ For changes before version 3.0, see ``HISTORY.rst``.
 
 - Provide ``AccessControl.get_safe_globals`` to facilitate safe use.
 
-- Use ``AC_PURE_PYTHON`` as switch to enable python implementation as default.
-  This should not be used except for tests and debugging.
+- Honor ``PURE_PYTHON`` environment variable to enable python implementation
+  during runtime.
 
 
 5.2 (2021-07-30)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,7 +7,6 @@ parts = interpreter test coverage
 
 [versions]
 AccessControl =
-RestrictedPython =
 
 [interpreter]
 recipe = zc.recipe.egg

--- a/src/AccessControl/ImplPython.py
+++ b/src/AccessControl/ImplPython.py
@@ -26,13 +26,8 @@ from Acquisition import aq_parent
 from ExtensionClass import Base
 from zope.interface import implementer
 
-# This is used when a permission maps explicitly to no permission.  We
-# try and get this from cAccessControl first to make sure that if both
-# security implementations exist, we can switch between them later.
-try:
-    from AccessControl.cAccessControl import _what_not_even_god_should_do
-except ImportError:
-    _what_not_even_god_should_do = []
+# We define our own `_what_not_even_god_should_do` to allow using PURE_PYTHON=1
+_what_not_even_god_should_do = []
 
 from AccessControl.interfaces import ISecurityManager
 from AccessControl.interfaces import ISecurityPolicy

--- a/src/AccessControl/ImplPython.py
+++ b/src/AccessControl/ImplPython.py
@@ -76,8 +76,8 @@ def rolesForPermissionOn(perm, object, default=_default_roles, n=None):
             roles = getattr(object, n)
             if roles is None:
                 if _embed_permission_in_roles:
-                    return ('Anonymous', n)
-                return 'Anonymous'
+                    return (('Anonymous',), n)
+                return ('Anonymous',)
 
             t = type(roles)
             if t is tuple:

--- a/src/AccessControl/ImplPython.py
+++ b/src/AccessControl/ImplPython.py
@@ -26,8 +26,12 @@ from Acquisition import aq_parent
 from ExtensionClass import Base
 from zope.interface import implementer
 
-# We define our own `_what_not_even_god_should_do` to allow using PURE_PYTHON=1
-_what_not_even_god_should_do = []
+PURE_PYTHON = int(os.environ.get('PURE_PYTHON', '0'))
+if PURE_PYTHON:
+    # We need our own to not depend on the C implementation:
+    _what_not_even_god_should_do = []
+else:
+    from AccessControl.cAccessControl import _what_not_even_god_should_do
 
 from AccessControl.interfaces import ISecurityManager
 from AccessControl.interfaces import ISecurityPolicy
@@ -37,6 +41,8 @@ from AccessControl.SimpleObjectPolicies import Containers
 from AccessControl.SimpleObjectPolicies import _noroles
 from AccessControl.unauthorized import Unauthorized
 from AccessControl.ZopeGuards import guarded_getitem  # NOQA
+
+
 # AccessControl.ZopeSecurityPolicy
 # --------------------------------
 #

--- a/src/AccessControl/Implementation.py
+++ b/src/AccessControl/Implementation.py
@@ -25,13 +25,12 @@ module was introduced.
 
 """
 from __future__ import absolute_import
+
 import os
 
-# We cannot use `PURE_PYTHON` as this would be propagated to `ExtensionClass`
-# and `Acquisition`. Due to restrictions of python implementation concerning
-# proxies it is not possible to run all with pure python and we influence only
-# the AccessControl implementation here.
-CAPI = not int(os.environ.get('AC_PURE_PYTHON', '0'))
+
+PURE_PYTHON = int(os.environ.get('PURE_PYTHON', '0'))
+CAPI = not PURE_PYTHON
 
 
 def getImplementationName():

--- a/src/AccessControl/Implementation.py
+++ b/src/AccessControl/Implementation.py
@@ -25,6 +25,13 @@ module was introduced.
 
 """
 from __future__ import absolute_import
+import os
+
+# We cannot use `PURE_PYTHON` as this would be propagated to `ExtensionClass`
+# and `Acquisition`. Due to restrictions of python implementation concerning
+# proxies it is not possible to run all with pure python and we influence only
+# the AccessControl implementation here.
+CAPI = not int(os.environ.get('AC_PURE_PYTHON', '0'))
 
 
 def getImplementationName():
@@ -96,7 +103,11 @@ _policy_names = {
                                          ),
 }
 
-setImplementation(_default_implementation)
+
+if CAPI:
+    setImplementation(_default_implementation)
+else:
+    setImplementation('PYTHON')
 
 # allow the implementation to change from the default
 _implementation_set = 0

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -14,6 +14,7 @@
 """Tests for the SecurityManager implementations
 """
 
+import os
 import unittest
 
 
@@ -250,6 +251,7 @@ class PythonSecurityManagerTests(SecurityManagerTestBase,
         return SecurityManager
 
 
+@unittest.skipIf(os.environ.get('PURE_PYTHON'), reason="Test expects C impl.")
 class C_SecurityManagerTests(SecurityManagerTestBase,
                              ISecurityManagerConformance,
                              unittest.TestCase):

--- a/src/AccessControl/tests/testZopeGuards.py
+++ b/src/AccessControl/tests/testZopeGuards.py
@@ -167,9 +167,11 @@ class TestGuardedHasattr(GuardTestCase):
     def setUp(self):
         self.__sm = SecurityManager()
         self.__old = self.setSecurityManager(self.__sm)
+        gc.disable()
 
     def tearDown(self):
         self.setSecurityManager(self.__old)
+        gc.enable()
 
     def test_miss(self):
         from AccessControl.ZopeGuards import guarded_hasattr

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -11,6 +11,7 @@
 #
 ##############################################################################
 
+import os
 import sys
 import unittest
 from doctest import DocTestSuite
@@ -775,9 +776,10 @@ class GetRolesWithMultiThreadTest(unittest.TestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(Python_ZSPTests))
-    suite.addTest(unittest.makeSuite(C_ZSPTests))
     suite.addTest(unittest.makeSuite(Python_SMTests))
-    suite.addTest(unittest.makeSuite(C_SMTests))
+    if not os.environ.get('PURE_PYTHON'):
+        suite.addTest(unittest.makeSuite(C_ZSPTests))
+        suite.addTest(unittest.makeSuite(C_SMTests))
     suite.addTest(DocTestSuite())
     suite.addTest(unittest.makeSuite(GetRolesWithMultiThreadTest))
     return suite

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ deps =
     setuptools < 52
     zc.buildout
 skip_install = true
+setenv =
+    PURE_PYTHON=1
 
 [testenv:coverage]
 basepython = python3


### PR DESCRIPTION
This is a first step to solve #117 . The integration of `.meta.toml` can be done afterwards.