### PR TITLE
Support PURE_PYTHON instead of AC_PURE_PYTHON

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,7 +231,7 @@ jobs:
           python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Run tests without C extensions
         run: |
-          AC_PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+          PURE_PYTHON=1 AC_PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Report Coverage
         run: |
           coverage combine

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - 2.7
@@ -171,6 +172,7 @@ jobs:
     needs: build-package
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - 2.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -233,7 +233,7 @@ jobs:
           python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Run tests without C extensions
         run: |
-          PURE_PYTHON=1 AC_PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+          PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Report Coverage
         run: |
           coverage combine

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,8 @@ For changes before version 3.0, see ``HISTORY.rst``.
 
 - Provide ``AccessControl.get_safe_globals`` to facilitate safe use.
 
-- Use ``AC_PURE_PYTHON`` as switch to enable python implementation as default.
-  This should not be used except for tests and debugging.
+- Honor ``PURE_PYTHON`` environment variable to enable python implementation
+  during runtime.
 
 
 5.2 (2021-07-30)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -7,8 +7,6 @@ parts = interpreter test coverage
 
 [versions]
 AccessControl =
-RestrictedPython =
-Acquisition = 4.10
 
 [interpreter]
 recipe = zc.recipe.egg

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,6 +8,7 @@ parts = interpreter test coverage
 [versions]
 AccessControl =
 RestrictedPython =
+Acquisition = 4.10
 
 [interpreter]
 recipe = zc.recipe.egg

--- a/src/AccessControl/ImplPython.py
+++ b/src/AccessControl/ImplPython.py
@@ -26,13 +26,8 @@ from Acquisition import aq_parent
 from ExtensionClass import Base
 from zope.interface import implementer
 
-# This is used when a permission maps explicitly to no permission.  We
-# try and get this from cAccessControl first to make sure that if both
-# security implementations exist, we can switch between them later.
-try:
-    from AccessControl.cAccessControl import _what_not_even_god_should_do
-except (ImportError, AttributeError):
-    _what_not_even_god_should_do = []
+# We define our own `_what_not_even_god_should_do` to allow using PURE_PYTHON=1
+_what_not_even_god_should_do = []
 
 from AccessControl.interfaces import ISecurityManager
 from AccessControl.interfaces import ISecurityPolicy

--- a/src/AccessControl/ImplPython.py
+++ b/src/AccessControl/ImplPython.py
@@ -31,7 +31,7 @@ from zope.interface import implementer
 # security implementations exist, we can switch between them later.
 try:
     from AccessControl.cAccessControl import _what_not_even_god_should_do
-except ImportError:
+except (ImportError, AttributeError):
     _what_not_even_god_should_do = []
 
 from AccessControl.interfaces import ISecurityManager

--- a/src/AccessControl/Implementation.py
+++ b/src/AccessControl/Implementation.py
@@ -25,7 +25,9 @@ module was introduced.
 
 """
 from __future__ import absolute_import
+
 import os
+
 
 # We cannot use `PURE_PYTHON` as this would be propagated to `ExtensionClass`
 # and `Acquisition`. Due to restrictions of python implementation concerning

--- a/src/AccessControl/Implementation.py
+++ b/src/AccessControl/Implementation.py
@@ -29,11 +29,8 @@ from __future__ import absolute_import
 import os
 
 
-# We cannot use `PURE_PYTHON` as this would be propagated to `ExtensionClass`
-# and `Acquisition`. Due to restrictions of python implementation concerning
-# proxies it is not possible to run all with pure python and we influence only
-# the AccessControl implementation here.
-CAPI = not int(os.environ.get('AC_PURE_PYTHON', '0'))
+PURE_PYTHON = int(os.environ.get('PURE_PYTHON', '0'))
+CAPI = not PURE_PYTHON
 
 
 def getImplementationName():

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -17,6 +17,7 @@
 import unittest
 import os
 
+
 _THREAD_ID = 123
 
 

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -14,8 +14,8 @@
 """Tests for the SecurityManager implementations
 """
 
-import unittest
 import os
+import unittest
 
 
 _THREAD_ID = 123

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -15,7 +15,7 @@
 """
 
 import unittest
-
+import os
 
 _THREAD_ID = 123
 
@@ -250,6 +250,7 @@ class PythonSecurityManagerTests(SecurityManagerTestBase,
         return SecurityManager
 
 
+@unittest.skipIf(os.environ.get('PURE_PYTHON'), reason="Test expects C impl.")
 class C_SecurityManagerTests(SecurityManagerTestBase,
                              ISecurityManagerConformance,
                              unittest.TestCase):

--- a/src/AccessControl/tests/testZopeGuards.py
+++ b/src/AccessControl/tests/testZopeGuards.py
@@ -167,9 +167,11 @@ class TestGuardedHasattr(GuardTestCase):
     def setUp(self):
         self.__sm = SecurityManager()
         self.__old = self.setSecurityManager(self.__sm)
+        gc.disable()
 
     def tearDown(self):
         self.setSecurityManager(self.__old)
+        gc.enable()
 
     def test_miss(self):
         from AccessControl.ZopeGuards import guarded_hasattr

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -12,6 +12,7 @@
 ##############################################################################
 
 import sys
+import os
 import unittest
 from doctest import DocTestSuite
 
@@ -775,9 +776,10 @@ class GetRolesWithMultiThreadTest(unittest.TestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(Python_ZSPTests))
-    suite.addTest(unittest.makeSuite(C_ZSPTests))
     suite.addTest(unittest.makeSuite(Python_SMTests))
-    suite.addTest(unittest.makeSuite(C_SMTests))
+    if not os.environ.get('PURE_PYTHON'):
+        suite.addTest(unittest.makeSuite(C_ZSPTests))
+        suite.addTest(unittest.makeSuite(C_SMTests))
     suite.addTest(DocTestSuite())
     suite.addTest(unittest.makeSuite(GetRolesWithMultiThreadTest))
     return suite

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -11,6 +11,7 @@
 #
 ##############################################################################
 
+import gc
 import sys
 import os
 import unittest
@@ -244,11 +245,14 @@ class ZopeSecurityPolicyTestBase(unittest.TestCase):
         eo = ImplictAcqObject()
         eo.getOwner = lambda: None
         self.context.stack.append(eo)
+        gc.collect()
         rc = sys.getrefcount(eo)
         self.testUserAccess()
+        gc.collect()
         self.assertEqual(rc, sys.getrefcount(eo))
         eo._proxy_roles = ()
         self.testUserAccess()
+        gc.collect()
         self.assertEqual(rc, sys.getrefcount(eo))
 
     def testAccessToUnprotectedSubobjects(self):

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -11,9 +11,8 @@
 #
 ##############################################################################
 
-import gc
-import sys
 import os
+import sys
 import unittest
 from doctest import DocTestSuite
 

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -245,14 +245,11 @@ class ZopeSecurityPolicyTestBase(unittest.TestCase):
         eo = ImplictAcqObject()
         eo.getOwner = lambda: None
         self.context.stack.append(eo)
-        gc.collect()
         rc = sys.getrefcount(eo)
         self.testUserAccess()
-        gc.collect()
         self.assertEqual(rc, sys.getrefcount(eo))
         eo._proxy_roles = ()
         self.testUserAccess()
-        gc.collect()
         self.assertEqual(rc, sys.getrefcount(eo))
 
     def testAccessToUnprotectedSubobjects(self):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
 skip_install = true
 setenv =
     PURE_PYTHON=1
-    AC_PURE_PYTHON=1
 
 [testenv:coverage]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,9 @@ deps =
     setuptools < 52
     zc.buildout
 skip_install = true
+setenv =
+    PURE_PYTHON=1
+    AC_PURE_PYTHON=1
 
 [testenv:coverage]
 basepython = python3


### PR DESCRIPTION
I fixed the obvious problems and disabled the tests which explicitly test the C implementation so only the actually problematic ones remain.

Locally I get the following result for these changes:

```
$ tox -epy39
py39 installed: zc.buildout==2.13.6
py39 run-test-pre: PYTHONHASHSEED='2895537127'
py39 run-test: commands[0] | /.../AccessControl/.tox/py39/bin/buildout -nc /.../AccessControl/buildout.cfg buildout:directory=/.../AccessControl/.tox/py39 buildout:develop=/.../AccessControl install test
Develop: '/.../AccessControl'
Updating test.
Generated script '/.../AccessControl/.tox/py39/bin/test'.
py39 run-test: commands[1] | /.../AccessControl/.tox/py39/bin/test --all -pvc
Running tests at all levels
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
    106/290 (36.6%) testPython (...ntrol.tests.testZopeGuards.TestActualPython)

Error in test testPython (AccessControl.tests.testZopeGuards.TestActualPython)
Traceback (most recent call last):
  File "/.../lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/.../lib/python3.9/unittest/case.py", line 592, in run
    self._callTestMethod(testMethod)
  File "/.../lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/.../AccessControl/src/AccessControl/tests/testZopeGuards.py", line 756, in testPython
    exec(code, its_globals)
  File "/.../AccessControl/src/AccessControl/tests/actual_python.py", line 115, in <module>
    f6()
  File "/.../AccessControl/src/AccessControl/tests/actual_python.py", line 97, in f6
    assert getattr(C, "display", None) == getattr(C, "display")
  File "/.../AccessControl/src/AccessControl/tests/testZopeGuards.py", line 655, in __call__
    return self.func(*args, **kws)
  File "/.../AccessControl/src/AccessControl/ImplPython.py", line 767, in guarded_getattr
    aq_acquire(inst, name, aq_validate, validate)
  File "/.../eggs/cp39/Acquisition-4.8-py3.9-macosx-11.0-x86_64.egg/Acquisition/__init__.py", line 802, in aq_acquire
    return aq_acquire(ImplicitAcquisitionWrapper(obj, parent),
  File "/.../eggs/cp39/Acquisition-4.8-py3.9-macosx-11.0-x86_64.egg/Acquisition/__init__.py", line 389, in __new__
    object.__setattr__(inst, '__dict__', obj.__dict__)
TypeError: __dict__ must be set to a dictionary, not a 'mappingproxy'

    107/290 (36.9%) testPythonRealAC (...tests.testZopeGuards.TestActualPython)

Error in test testPythonRealAC (AccessControl.tests.testZopeGuards.TestActualPython)
Traceback (most recent call last):
  File "/.../lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/.../lib/python3.9/unittest/case.py", line 592, in run
    self._callTestMethod(testMethod)
  File "/.../lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/.../AccessControl/src/AccessControl/tests/testZopeGuards.py", line 769, in testPythonRealAC
    exec(code, its_globals)
  File "/.../AccessControl/src/AccessControl/tests/actual_python.py", line 115, in <module>
    f6()
  File "/.../AccessControl/src/AccessControl/tests/actual_python.py", line 97, in f6
    assert getattr(C, "display", None) == getattr(C, "display")
  File "/.../AccessControl/src/AccessControl/ImplPython.py", line 767, in guarded_getattr
    aq_acquire(inst, name, aq_validate, validate)
  File "/.../eggs/cp39/Acquisition-4.8-py3.9-macosx-11.0-x86_64.egg/Acquisition/__init__.py", line 802, in aq_acquire
    return aq_acquire(ImplicitAcquisitionWrapper(obj, parent),
  File "/.../eggs/cp39/Acquisition-4.8-py3.9-macosx-11.0-x86_64.egg/Acquisition/__init__.py", line 389, in __new__
    object.__setattr__(inst, '__dict__', obj.__dict__)
TypeError: __dict__ must be set to a dictionary, not a 'mappingproxy'

    121/290 (41.7%) testIdentityProxy (...stZopeSecurityPolicy.Python_ZSPTests)

Failure in test testIdentityProxy (AccessControl.tests.testZopeSecurityPolicy.Python_ZSPTests)
Traceback (most recent call last):
  File "/.../lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/.../lib/python3.9/unittest/case.py", line 592, in run
    self._callTestMethod(testMethod)
  File "/.../lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/.../AccessControl/src/AccessControl/tests/testZopeSecurityPolicy.py", line 249, in testIdentityProxy
    self.assertEqual(rc, sys.getrefcount(eo))
  File "/.../lib/python3.9/unittest/case.py", line 837, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/.../lib/python3.9/unittest/case.py", line 830, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: 3 != 12


  Ran 290 tests with 1 failures, 2 errors, 21 skipped in 0.200 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.

Tests with errors:
   testPython (AccessControl.tests.testZopeGuards.TestActualPython)
   testPythonRealAC (AccessControl.tests.testZopeGuards.TestActualPython)

Tests with failures:
   testIdentityProxy (AccessControl.tests.testZopeSecurityPolicy.Python_ZSPTests)
ERROR: InvocationError for command /.../AccessControl/.tox/py39/bin/test --all -pvc (exited with code 1)
_________________________________________________________________________ summary __________________________________________________________________________
ERROR:   py39: commands failed
```

See #119 for the base of this PR.