### PR TITLE
Update to the latest c-code template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.
@@ -91,6 +91,7 @@ jobs:
     # Sigh. Note that the matrix must be kept in sync
     # with `test`, and `docs` must use a subset.
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +103,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.5"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -139,8 +140,8 @@ jobs:
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build AccessControl (3.11.0-beta.5)
-        if: ${{ startsWith(matrix.python-version, '3.11.0-beta.5') }}
+      - name: Build AccessControl (3.11.0-rc.1)
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -195,7 +196,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-beta.5')
+          && !startsWith(matrix.python-version, '3.11.0-rc.1')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -215,7 +216,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-beta.5"
+          - "3.11.0-rc.1"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -252,8 +253,8 @@ jobs:
         with:
           name: AccessControl-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install AccessControl 3.11.0-beta.5
-        if: ${{ startsWith(matrix.python-version, '3.11.0-beta.5') }}
+      - name: Install AccessControl 3.11.0-rc.1
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           pip install -U wheel setuptools
           # coverage has a wheel on PyPI for a future python version which is
@@ -266,7 +267,7 @@ jobs:
           unzip -n dist/AccessControl-*whl -d src
           pip install --pre -U -e .[test]
       - name: Install AccessControl
-        if: ${{ !startsWith(matrix.python-version, '3.11.0-beta.5') }}
+        if: ${{ !startsWith(matrix.python-version, '3.11.0-rc.1') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "d5b6c610d0ec7f0b8f6bbba49353eb89288f62b1"
+commit-id = "8098b69c4f646a6a94ba55d18a9655bd9667ae77"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ For changes before version 3.0, see ``HISTORY.rst``.
 5.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Switch from ``-Ofast`` to ``-O3`` when compiling code for Linux wheels.
 
 
 5.4 (2022-08-26)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ For changes before version 3.0, see ``HISTORY.rst``.
 ----------------
 
 - Switch from ``-Ofast`` to ``-O3`` when compiling code for Linux wheels.
+  (`#133 <https://github.com/zopefoundation/AccessControl/pull/133>`_)
 
 
 5.4 (2022-08-26)


### PR DESCRIPTION
Fix regression for CFLAGS having -Ofast, which is known to break things.  See https://github.com/zopefoundation/meta/pull/155 for reference.