### PR TITLE
Finalize Python 3.12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-alpha.7"
+          - "3.12"
         os: [ubuntu-20.04, macos-11]
 
     steps:
@@ -174,15 +174,7 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
-      - name: Install AccessControl and dependencies (3.12.0-alpha.7)
-        if: matrix.python-version == '3.12.0-alpha.7'
-        run: |
-          # Install to collect dependencies into the (pip) cache.
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          pip install --pre .[test]
       - name: Install AccessControl and dependencies
-        if: matrix.python-version != '3.12.0-alpha.7'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -226,7 +218,6 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.12.0-alpha.7')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -244,7 +235,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12.0-alpha.7"
+          - "3.12"
         os: [ubuntu-20.04, macos-11]
 
     steps:
@@ -278,22 +269,7 @@ jobs:
         with:
           name: AccessControl-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install AccessControl 3.12.0-alpha.7
-        if: ${{ startsWith(matrix.python-version, '3.12.0-alpha.7') }}
-        run: |
-          pip install -U wheel setuptools
-          # coverage has a wheel on PyPI for a future python version which is
-          # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage
-          # Unzip into src/ so that testrunner can find the .so files
-          # when we ask it to load tests from that directory. This
-          # might also save some build time?
-          unzip -n dist/AccessControl-*whl -d src
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          pip install --pre -U -e .[test]
       - name: Install AccessControl
-        if: ${{ !startsWith(matrix.python-version, '3.12.0-alpha.7') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -28,12 +28,12 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
-        *"cp312"*) echo 'py312';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
         *"cp310"*) echo 'py310';;
         *"cp311"*) echo 'py311';;
+        *"cp312"*) echo 'py312';;
         *) echo 'py';;
     esac
 }
@@ -41,19 +41,14 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
-       [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
+       [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        if [[ "${PYBIN}" == *"cp312"* ]] ; then
-            "${PYBIN}/pip" install --pre -e /io/
-            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
-        else
-            "${PYBIN}/pip" install -e /io/
-            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
-        fi
+        "${PYBIN}/pip" install -e /io/
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,13 +2,13 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "a361e1fd"
+commit-id = "cb0568c7"
 
 [python]
 with-appveyor = true
 with-windows = false
 with-pypy = false
-with-future-python = true
+with-future-python = false
 with-sphinx-doctests = false
 with-macos = false
 

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "fe63cb4c"
+commit-id = "a361e1fd"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,10 @@ Changelog
 
 For changes before version 3.0, see ``HISTORY.rst``.
 
-6.3 (unreleased)
+6.3 (2023-10-05)
 ----------------
 
-- Nothing changed yet.
+- Add support for Python 3.12.
 
 
 6.2 (2023-09-04)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,7 @@ environment:
     - python: 39-x64
     - python: 310-x64
     - python: 311-x64
-    # `multibuild` cannot install non-final versions as they are not on
-    # ftp.python.org, so we skip Python 3.11 until its final release:
-    # - python: 312-x64
+    - python: 312-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ ext_modules = [
                  join('include', 'Acquisition', 'Acquisition.h')]),
 ]
 
-version = '6.3.dev0'
+version = '6.3'
 
 
 setup(name='AccessControl',
@@ -65,6 +65,7 @@ setup(name='AccessControl',
           'Programming Language :: Python :: 3.9',
           'Programming Language :: Python :: 3.10',
           'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
           'Programming Language :: Python :: Implementation :: CPython',
       ],
       ext_modules=ext_modules,

--- a/tox.ini
+++ b/tox.ini
@@ -14,11 +14,12 @@ envlist =
 
 [testenv]
 usedevelop = true
-pip_pre = py312: true
 deps =
 setenv =
     pure: PURE_PYTHON=1
     !pure-!pypy3: PURE_PYTHON=0
+    py312: VIRTUALENV_PIP=23.1.2
+    py312: PIP_REQUIRE_VIRTUALENV=0
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -38,21 +38,31 @@ commands =
     coverage run -m zope.testrunner --test-path=src {posargs:-vc}
     coverage html -i
     coverage report -i -m --fail-under=80
+[testenv:release-check]
+description = ensure that the distribution is ready to release
+basepython = python3
+skip_install = true
+deps =
+    twine
+    build
+    check-manifest
+    check-python-versions >= 0.20.0
+    wheel
+commands =
+    check-manifest
+    check-python-versions
+    python -m build --sdist --no-isolation
+    twine check dist/*
 
 [testenv:lint]
 basepython = python3
 skip_install = true
+deps =
+    isort
+    flake8
 commands =
     isort --check-only --diff {toxinidir}/src {toxinidir}/setup.py
     flake8 src setup.py
-    check-manifest
-    check-python-versions
-deps =
-    check-manifest
-    check-python-versions >= 0.19.1
-    wheel
-    flake8
-    isort
 
 [testenv:isort-apply]
 basepython = python3


### PR DESCRIPTION
RestrictedPython is a direct dependency here, so merging this PR and making a new AccessControl release must wait for https://github.com/zopefoundation/RestrictedPython/issues/246
