### PR TITLE
Remove preliminary support for Python 3.13 as it is not yet ready.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
           # cffi will probably have no public release until a Python 3.13 beta
           # or even RC release, see https://github.com/python-cffi/cffi/issues/23
           echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          PIP_CONSTRAINT=cffi_constraint.txt pip install cffi
+          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install cffi
       - name: Install Build Dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
@@ -194,7 +194,7 @@ jobs:
           echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=cffi_constraint.txt pip install --pre .[test]
+          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre .[test]
       - name: Install AccessControl and dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
@@ -309,7 +309,7 @@ jobs:
           unzip -n dist/AccessControl-*whl -d src
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=cffi_constraint.txt pip install --pre -U -e .[test]
+          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre -U -e .[test]
       - name: Install AccessControl
         if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
 
     steps:
@@ -131,17 +130,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
-        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
-        run: |
-          pip install -U pip
-          pip install -U setuptools wheel twine
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install cffi
       - name: Install Build Dependencies
-        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
           pip install -U setuptools wheel twine cffi
@@ -185,18 +174,7 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
-      - name: Install AccessControl and dependencies (3.13.0-alpha - 3.13.0)
-        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
-        run: |
-          # Install to collect dependencies into the (pip) cache.
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre .[test]
       - name: Install AccessControl and dependencies
-        if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
           pip install .[test]
@@ -240,7 +218,6 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -259,7 +236,6 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13.0-alpha - 3.13.0"
         os: [ubuntu-20.04, macos-11]
 
     steps:
@@ -293,25 +269,7 @@ jobs:
         with:
           name: AccessControl-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install AccessControl 3.13.0-alpha - 3.13.0
-        if: ${{ startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
-        run: |
-          pip install -U wheel setuptools
-          # cffi will probably have no public release until a beta or even RC
-          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
-          echo 'cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58 ; platform_python_implementation == "CPython"' > cffi_constraint.txt
-          # coverage has a wheel on PyPI for a future python version which is
-          # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage
-          # Unzip into src/ so that testrunner can find the .so files
-          # when we ask it to load tests from that directory. This
-          # might also save some build time?
-          unzip -n dist/AccessControl-*whl -d src
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre -U -e .[test]
       - name: Install AccessControl
-        if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage

--- a/.manylinux-install.sh
+++ b/.manylinux-install.sh
@@ -28,7 +28,6 @@ yum -y install libffi-devel
 
 tox_env_map() {
     case $1 in
-        *"cp313"*) echo 'py313';;
         *"cp37"*) echo 'py37';;
         *"cp38"*) echo 'py38';;
         *"cp39"*) echo 'py39';;
@@ -42,20 +41,14 @@ tox_env_map() {
 # Compile wheels
 for PYBIN in /opt/python/*/bin; do
     if \
-       [[ "${PYBIN}" == *"cp313"* ]] || \
        [[ "${PYBIN}" == *"cp311"* ]] || \
        [[ "${PYBIN}" == *"cp312"* ]] || \
        [[ "${PYBIN}" == *"cp37"* ]] || \
        [[ "${PYBIN}" == *"cp38"* ]] || \
        [[ "${PYBIN}" == *"cp39"* ]] || \
        [[ "${PYBIN}" == *"cp310"* ]] ; then
-        if [[ "${PYBIN}" == *"cp313"* ]] ; then
-            "${PYBIN}/pip" install --pre -e /io/
-            "${PYBIN}/pip" wheel /io/ --pre -w wheelhouse/
-        else
-            "${PYBIN}/pip" install -e /io/
-            "${PYBIN}/pip" wheel /io/ -w wheelhouse/
-        fi
+        "${PYBIN}/pip" install -e /io/
+        "${PYBIN}/pip" wheel /io/ -w wheelhouse/
         if [ `uname -m` == 'aarch64' ]; then
           cd /io/
           ${PYBIN}/pip install tox

--- a/.meta.toml
+++ b/.meta.toml
@@ -8,7 +8,7 @@ commit-id = "1351c95d"
 with-appveyor = true
 with-windows = false
 with-pypy = false
-with-future-python = true
+with-future-python = false
 with-sphinx-doctests = false
 with-macos = false
 

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "fc37b50c"
+commit-id = "1351c95d"
 
 [python]
 with-appveyor = true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ environment:
     - python: 310-x64
     - python: 311-x64
     - python: 312-x64
-    # `multibuild` cannot install non-final versions as they are not on
-    # ftp.python.org, so we skip Python 3.13 until its final release:
-    # - python: 313-x64
 
 install:
   - "SET PYTHONVERSION=%PYTHON%"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
-[bdist_wheel]
-universal = 0
 
 [zest.releaser]
 create-wheel = no

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,10 @@ envlist =
     py310,py310-pure
     py311,py311-pure
     py312,py312-pure
-    py313,py313-pure
     coverage
 
 [testenv]
 usedevelop = true
-pip_pre = py313: true
 deps =
 setenv =
     pure: PURE_PYTHON=1


### PR DESCRIPTION
This is needed to get the tests on `master` green until #144 is fixed.