### PR TITLE
Make dict views behave like their unrestricted versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ For changes before version 3.0, see ``HISTORY.rst``.
 
 - Nothing changed yet.
 
+- Make dict views (`.keys()`, `.items()` and `.values()`) behave like their
+  unrestricted versions.
+  (`#147 <https://github.com/zopefoundation/AccessControl/pull/147>`_)
+
+- Make `.items()` validate each keys and values, like `.keys()` and
+  `.values()` do.
+
 
 6.3 (2023-11-20)
 ----------------

--- a/src/AccessControl/tests/actual_python.py
+++ b/src/AccessControl/tests/actual_python.py
@@ -123,6 +123,39 @@ def f7():
         access = getattr(d, meth)
         result = sorted(access())
         assert result == expected[kind], (meth, kind, result, expected[kind])
+        assert len(access()) == len(expected[kind]), (meth, kind, "len")
+        iter_ = access()  # iterate twice on the same view
+        assert list(iter_) == list(iter_)
+
+        assert sorted([k for k in getattr(d, meth)()]) == expected[kind]
+        assert sorted(k for k in getattr(d, meth)()) == expected[kind]
+    assert {k: v for k, v in d.items()} == d
+
+    assert 1 in d
+    assert 1 in d.keys()
+    assert 2 in d.values()
+    assert (1, 2) in d.items()
+
+    assert d
+    assert d.keys()
+    assert d.values()
+    assert d.items()
+
+    empty_d = {}
+    assert not empty_d
+    assert not empty_d.keys()
+    assert not empty_d.values()
+    assert not empty_d.items()
+
+    smaller_d = {1: 2}
+    for m, _ in methods:
+        assert getattr(d, m)() != getattr(smaller_d, m)()
+        assert not getattr(d, m)() == getattr(smaller_d, m)()
+        if m != 'values':
+            assert getattr(d, m)() > getattr(smaller_d, m)()
+            assert getattr(d, m)() >= getattr(smaller_d, m)()
+            assert getattr(smaller_d, m)() < getattr(d, m)()
+            assert getattr(smaller_d, m)() <= getattr(d, m)()
 
 
 f7()


### PR DESCRIPTION
unlike the restricted versions, the unrestricted versions:
 - are not iterators, they are views
 - have a len
 - are false when the mapping is empty, true otherwise
 - are instances of collections.abc.MappingView

This change aligns the behavior of restricted versions with the behavior of unrestricted one, while keeping the "guard", which validates the access with the security manager.

During this refactoring, also change `.items()` to validate each keys and values, like `.keys()` and `.values()` do.