### PR TITLE
Fix build errors on recent macOS versions.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,6 +15,7 @@ source =
 [report]
 show_missing = true
 precision = 2
+ignore_errors = True
 exclude_lines =
     except ImportError:
     if __name__ == '__main__':

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,14 +6,14 @@ For changes before version 3.0, see ``HISTORY.rst``.
 6.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
 - Make dict views (`.keys()`, `.items()` and `.values()`) behave like their
   unrestricted versions.
   (`#147 <https://github.com/zopefoundation/AccessControl/pull/147>`_)
 
 - Make `.items()` validate each keys and values, like `.keys()` and
   `.values()` do.
+
+- Fix build errors on recent macOS versions.
 
 
 6.3 (2023-11-20)

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -425,7 +425,7 @@ static PyExtensionClass ZopeSecurityPolicyType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) ZopeSecurityPolicy_dealloc,/* tp_dealloc	*/
-	0,  					/* tp_print	*/
+	0,  					/* tp_vectorcall_offset	*/
 	NULL,					/* tp_getattr	*/
 	NULL,					/* tp_setattr	*/
 	NULL,					/* tp_compare	*/
@@ -543,7 +543,7 @@ static PyExtensionClass PermissionRoleType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) PermissionRole_dealloc,	/* tp_dealloc	*/
-	0,  					/* tp_print	*/
+	0,  					/* tp_vectorcall_offset	*/
 	NULL,					/* tp_getattr	*/
 	NULL,					/* tp_setattr	*/
 	NULL,					/* tp_compare	*/
@@ -613,7 +613,7 @@ static PyExtensionClass imPermissionRoleType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) imPermissionRole_dealloc,	/* tp_dealloc	*/
-	0,  					/* tp_print	*/
+	0,  					/* tp_vectorcall_offset	*/
 	NULL,					/* tp_getattr	*/
 	NULL,	                                /* tp_setattr	*/
 	NULL,					/* tp_compare	*/

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -425,7 +425,7 @@ static PyExtensionClass ZopeSecurityPolicyType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) ZopeSecurityPolicy_dealloc,/* tp_dealloc	*/
-	NULL,					/* tp_print	*/
+	0,  					/* tp_print	*/
 	NULL,					/* tp_getattr	*/
 	NULL,					/* tp_setattr	*/
 	NULL,					/* tp_compare	*/
@@ -484,7 +484,7 @@ static PyExtensionClass SecurityManagerType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) SecurityManager_dealloc,/* tp_dealloc	*/
-	NULL,					/* tp_print	*/
+	0,  					/* tp_print	*/
 	NULL,					/* tp_getattr	*/
 	NULL,					/* tp_setattr	*/
 	NULL,					/* tp_compare	*/
@@ -543,7 +543,7 @@ static PyExtensionClass PermissionRoleType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) PermissionRole_dealloc,	/* tp_dealloc	*/
-	NULL,					/* tp_print	*/
+	0,  					/* tp_print	*/
 	NULL,					/* tp_getattr	*/
 	NULL,					/* tp_setattr	*/
 	NULL,					/* tp_compare	*/
@@ -613,7 +613,7 @@ static PyExtensionClass imPermissionRoleType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) imPermissionRole_dealloc,	/* tp_dealloc	*/
-	NULL,					/* tp_print	*/
+	0,  					/* tp_print	*/
 	NULL,					/* tp_getattr	*/
 	NULL,	                                /* tp_setattr	*/
 	NULL,					/* tp_compare	*/

--- a/src/AccessControl/cAccessControl.c
+++ b/src/AccessControl/cAccessControl.c
@@ -484,7 +484,7 @@ static PyExtensionClass SecurityManagerType = {
 	0,					/* tp_itemsize	*/
 	/* Standard methods 	*/
 	(destructor) SecurityManager_dealloc,/* tp_dealloc	*/
-	0,  					/* tp_print	*/
+	0,  					/* tp_vectorcall_offset*/
 	NULL,					/* tp_getattr	*/
 	NULL,					/* tp_setattr	*/
 	NULL,					/* tp_compare	*/


### PR DESCRIPTION
<details>
<summary>Traceback without these changes</summary>

```
py311: packaging backend failed (code=error: command '/usr/bin/clang' failed with exit code 1), with SystemExit: error: command '/usr/bin/clang' failed with exit code 1
src/AccessControl/cAccessControl.c:428:2: error: incompatible pointer to integer conversion initializing 'Py_ssize_t' (aka 'long') with an expression of type 'void *'
      [-Wint-conversion]
        NULL,                                   /* tp_print     */
        ^~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_null.h:30:15: note: expanded from macro 'NULL'
#define NULL  __DARWIN_NULL
              ^~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
#define __DARWIN_NULL ((void *)0)
                      ^~~~~~~~~~~
src/AccessControl/cAccessControl.c:487:2: error: incompatible pointer to integer conversion initializing 'Py_ssize_t' (aka 'long') with an expression of type 'void *'
      [-Wint-conversion]
        NULL,                                   /* tp_print     */
        ^~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_null.h:30:15: note: expanded from macro 'NULL'
#define NULL  __DARWIN_NULL
              ^~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
#define __DARWIN_NULL ((void *)0)
                      ^~~~~~~~~~~
src/AccessControl/cAccessControl.c:546:2: error: incompatible pointer to integer conversion initializing 'Py_ssize_t' (aka 'long') with an expression of type 'void *'
      [-Wint-conversion]
        NULL,                                   /* tp_print     */
        ^~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_null.h:30:15: note: expanded from macro 'NULL'
#define NULL  __DARWIN_NULL
              ^~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
#define __DARWIN_NULL ((void *)0)
                      ^~~~~~~~~~~
src/AccessControl/cAccessControl.c:616:2: error: incompatible pointer to integer conversion initializing 'Py_ssize_t' (aka 'long') with an expression of type 'void *'
      [-Wint-conversion]
        NULL,                                   /* tp_print     */
        ^~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types/_null.h:30:15: note: expanded from macro 'NULL'
#define NULL  __DARWIN_NULL
              ^~~~~~~~~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/_types.h:52:23: note: expanded from macro '__DARWIN_NULL'
#define __DARWIN_NULL ((void *)0)
                      ^~~~~~~~~~~
4 errors generated.
```
</details>

I am running on Sonoma 14.4.1 on an Apple chip.

The `PyExtensionClass` is actually a `PyTypeObject` and the examples in the Python docs also use a `0` here instead of `NULL`: https://docs.python.org/3/c-api/typeobj.html#typedef-examples