### PR TITLE
Respect `PURE_PYTHON` environment variable set to `0`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ For changes before version 3.0, see ``HISTORY.rst``.
 7.1 (unreleased)
 ----------------
 
+- Respect ``PURE_PYTHON`` environment variable set to ``0`` when running tests.
+
 
 7.0 (2024-05-30)
 ----------------

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -14,7 +14,6 @@
 """Tests for the SecurityManager implementations
 """
 
-import os
 import unittest
 
 from ..Implementation import PURE_PYTHON

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -251,7 +251,8 @@ class PythonSecurityManagerTests(SecurityManagerTestBase,
         return SecurityManager
 
 
-@unittest.skipIf(os.environ.get('PURE_PYTHON'), reason="Test expects C impl.")
+@unittest.skipIf(int(os.environ.get('PURE_PYTHON', '0')),
+                 reason="Test expects C impl.")
 class C_SecurityManagerTests(SecurityManagerTestBase,
                              ISecurityManagerConformance,
                              unittest.TestCase):

--- a/src/AccessControl/tests/testSecurityManager.py
+++ b/src/AccessControl/tests/testSecurityManager.py
@@ -17,6 +17,8 @@
 import os
 import unittest
 
+from ..Implementation import PURE_PYTHON
+
 
 _THREAD_ID = 123
 
@@ -251,8 +253,7 @@ class PythonSecurityManagerTests(SecurityManagerTestBase,
         return SecurityManager
 
 
-@unittest.skipIf(int(os.environ.get('PURE_PYTHON', '0')),
-                 reason="Test expects C impl.")
+@unittest.skipIf(PURE_PYTHON, reason="Test expects C impl.")
 class C_SecurityManagerTests(SecurityManagerTestBase,
                              ISecurityManagerConformance,
                              unittest.TestCase):

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -27,6 +27,8 @@ from zExceptions import Unauthorized
 from AccessControl.SecurityManagement import SecurityContext
 from AccessControl.userfolder import UserFolder
 
+from ..Implementation import PURE_PYTHON
+
 
 user_roles = ('RoleOfUser',)
 eo_roles = ('RoleOfExecutableOwner',)
@@ -772,7 +774,7 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(Python_ZSPTests))
     suite.addTest(
         unittest.defaultTestLoader.loadTestsFromTestCase(Python_SMTests))
-    if not int(os.environ.get('PURE_PYTHON', '0')):
+    if not PURE_PYTHON:
         suite.addTest(
             unittest.defaultTestLoader.loadTestsFromTestCase(C_ZSPTests))
         suite.addTest(

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -772,7 +772,7 @@ def test_suite():
         unittest.defaultTestLoader.loadTestsFromTestCase(Python_ZSPTests))
     suite.addTest(
         unittest.defaultTestLoader.loadTestsFromTestCase(Python_SMTests))
-    if not os.environ.get('PURE_PYTHON'):
+    if not int(os.environ.get('PURE_PYTHON', '0')):
         suite.addTest(
             unittest.defaultTestLoader.loadTestsFromTestCase(C_ZSPTests))
         suite.addTest(

--- a/src/AccessControl/tests/testZopeSecurityPolicy.py
+++ b/src/AccessControl/tests/testZopeSecurityPolicy.py
@@ -12,7 +12,6 @@
 ##############################################################################
 
 import _thread as thread
-import os
 import sys
 import unittest
 from doctest import DocTestSuite


### PR DESCRIPTION
Setting to 0 should be equivalent to not setting the variable.

Refs https://github.com/zopefoundation/meta/issues/283