### PR TITLE
Add caching to guarded_import to boost performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ For changes before version 3.0, see ``HISTORY.rst``.
 7.4 (unreleased)
 ----------------
 
+- Add caching for ``guarded_import`` in Python Scripts. This can speed up the
+  execution of Scripts considerably if they use many ``import`` statements.
 
 7.3 (2025-11-16)
 ----------------

--- a/src/AccessControl/ZopeGuards.py
+++ b/src/AccessControl/ZopeGuards.py
@@ -416,6 +416,12 @@ safe_builtins['zip'] = guarded_zip
 
 import_default_level = 0
 
+# Cache of (mname, fromlist) pairs whose security check has already passed.
+# Module security in Zope is configured globally, so the result is the same
+# for every request/user — skipping the repeated validate() calls saves
+# significant CPU on instances where Scripts run many imports per request.
+_guarded_import_cache = set()
+
 
 def guarded_import(mname, globals=None, locals=None, fromlist=None,
                    level=import_default_level):
@@ -430,6 +436,10 @@ def guarded_import(mname, globals=None, locals=None, fromlist=None,
         raise Unauthorized("Using import with a level specification isn't "
                            "supported by AccessControl: %s" % mname)
 
+    cache_key = (mname, tuple(fromlist))
+    if cache_key in _guarded_import_cache:
+        return __import__(mname, globals, locals, fromlist)
+
     mnameparts = mname.split('.')
     validate = getSecurityManager().validate
     module = load_module(None, None, mnameparts, validate, globals, locals)
@@ -443,6 +453,7 @@ def guarded_import(mname, globals=None, locals=None, fromlist=None,
         if not validate(module, module, name, v):
             raise Unauthorized
     else:
+        _guarded_import_cache.add(cache_key)
         return __import__(mname, globals, locals, fromlist)
 
 


### PR DESCRIPTION
Using "import" in Python Scripts triggers the execution of guarded_import each time. This performs a security test and then the import itself. The import is fast because the Python interpreter caches this. The security test is costly, and always yields the same result. This patch inserts a cache to skip this test on repeated executions, speeding up the Python Scripts.

- [x] I signed and returned the [Zope Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the zopefoundation GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Developer guidelines](https://www.zope.dev/developer/guidelines.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added documentation for my changes.
- [x] I included a change log entry in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #
