### PR TITLE
Fix guarded_getattr ImplPython/ImplC assertion-key parity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,14 @@ For changes before version 3.0, see ``HISTORY.rst``.
 7.4 (unreleased)
 ----------------
 
+- Fix a parity defect between the Python and C implementations of
+  ``guarded_getattr``: the pure-Python implementation keyed the container
+  assertion on ``type(value.__self__)`` instead of ``type(inst)``, so under
+  ``PURE_PYTHON`` a bound method of an allow-listed simple type (e.g.
+  ``tuple``/``bytes``/``range``) was returned without calling ``validate()``.
+  The Python implementation now keys on ``type(inst)``, matching the C
+  implementation, and a regression test guards the behaviour.
+
 - Add preliminary support for Python 3.15 as of 3.15b1.
 
 - Add support for automatically building and publishing Windows/ARM64 wheels.

--- a/src/AccessControl/ImplPython.py
+++ b/src/AccessControl/ImplPython.py
@@ -733,12 +733,14 @@ def guarded_getattr(inst, name, default=_marker):
             return default
         raise
 
-    try:
-        container = v.__self__
-    except AttributeError:
-        container = aq_parent(aq_inner(v)) or inst
-
-    assertion = Containers(type(container))
+    # The container assertion must be keyed on the type of the accessed
+    # object, to match the C implementation (see ``cAccessControl.c``, which
+    # uses ``Containers(type(inst))``).  Keying on ``type(v.__self__)``
+    # instead let a bound method whose ``__self__`` is an allow-listed simple
+    # type (e.g. ``tuple``, ``bytes``, ``range``) take the truthy-assertion
+    # short-circuit and be returned without calling ``validate()`` -- a
+    # divergence from the C engine.
+    assertion = Containers(type(inst))
 
     if isinstance(assertion, dict):
         # We got a table that lets us reason about individual

--- a/src/AccessControl/tests/testZopeGuards.py
+++ b/src/AccessControl/tests/testZopeGuards.py
@@ -119,6 +119,25 @@ class TestGuardedGetattr(GuardTestCase):
         guarded_getattr(self, 'test_calls_validate_for_unknown_type')
         self.assertEqual(len(self.__sm.calls), 1)
 
+    def test_validates_bound_method_of_allow_listed_type(self):
+        # A bound method whose ``__self__`` is an allow-listed simple type
+        # (here a ``tuple``), accessed as an attribute of an object that has
+        # no container assertion of its own, must still be routed through
+        # ``validate()``.  The assertion lookup keys on the type of the
+        # accessed object (``type(inst)``), not on ``type(value.__self__)`` --
+        # otherwise the pure-Python engine short-circuits and diverges from
+        # the C engine, returning the method without a permission check.
+        from AccessControl import Unauthorized
+        from AccessControl.ZopeGuards import guarded_getattr
+
+        class Protected:
+            feed = (1, 2, 3).count  # bound method of an allow-listed tuple
+
+        obj = Protected()
+        self.__sm.reject = True
+        self.assertRaises(Unauthorized, guarded_getattr, obj, 'feed')
+        self.assertEqual(len(self.__sm.calls), 1)
+
     def test_attr_handler_table(self):
         from AccessControl import Unauthorized
         from AccessControl.SimpleObjectPolicies import ContainerAssertions


### PR DESCRIPTION
Closes #166.

## What

`guarded_getattr` derived its container-assertion lookup key from different objects in the two implementations:

- `ImplPython` keyed on `type(value.__self__)` (`src/AccessControl/ImplPython.py`).
- `cAccessControl` keys on `type(inst)` (`src/AccessControl/cAccessControl.c`, whose own comment reads `assertion = Containers(type(inst))`).

When an attribute of an object that has **no** container assertion is a **bound method whose `__self__` is an allow-listed simple type** (`tuple`, `bytes`, `range`, the BTree `*Items` views, `dict_keys`/`dict_values`/`dict_items`, or any `allow_type(T, 1)` type), the pure-Python engine took the truthy-assertion short-circuit and returned the value **without calling `validate()`**, while the C engine routed through `validate()`. So the two engines could reach different access decisions, and under `PURE_PYTHON` / PyPy the permission check was skipped.

## Fix

Key the assertion short-circuit in `ImplPython.guarded_getattr` on `type(inst)`, matching `cAccessControl`. (The `value.__self__` derivation was the only difference; the rest of the function already mirrors the C logic.)

## Test

Added `TestGuardedGetattr.test_validates_bound_method_of_allow_listed_type`, which accesses an attribute that is a bound method of an allow-listed `tuple` on an object with no container assertion under a rejecting `SecurityManager`, and asserts `Unauthorized` is raised and `validate()` is called.

- Without the fix, under `PURE_PYTHON=1`: the new test **fails** (`Unauthorized not raised by guarded_getattr`).
- With the fix: passes under both engines.

Full suite green on CPython 3.14.3:
- C engine: `Ran 320 tests with 0 failures, 0 errors`.
- `PURE_PYTHON=1`: `Ran 299 tests with 0 failures, 0 errors and 21 skipped`.